### PR TITLE
Add a leading /** to /target in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/target
+/**/target/
 **/*.rs.bk

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/**/target/
+/**/target
 **/*.rs.bk


### PR DESCRIPTION
This is needed to ignore the target directory that is created by `cd runtime/wasm && ./build.sh && cd ../..` (as well as any potential future target directories).