### PR TITLE
Switch to own DigestItem impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2417,6 +2417,7 @@ dependencies = [
  "shasper-consensus-primitives 0.1.0",
  "shasper-crypto 0.1.0",
  "shasper-primitives 0.1.0",
+ "shasper-runtime 0.9.0",
  "sr-io 0.1.0 (git+https://github.com/paritytech/substrate)",
  "sr-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
  "sr-version 0.1.0 (git+https://github.com/paritytech/substrate)",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -15,6 +15,7 @@ sr-version = { git = "https://github.com/paritytech/substrate" }
 sr-io = { git = "https://github.com/paritytech/substrate" }
 shasper-consensus-primitives = { path = "primitives" }
 shasper-crypto = { path = "../crypto" }
+shasper-runtime = { path = "../runtime" }
 
 srml-consensus = { git = "https://github.com/paritytech/substrate" }
 futures = "0.1.17"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -144,7 +144,7 @@ impl traits::DigestItem for DigestItem {
 		}
 	}
 
-	fn as_changes_trie_root(&self) -> Option<&H256> {
+	fn as_changes_trie_root(&self) -> Option<&Self::Hash> {
 		match self {
 			DigestItem::ChangesTrieRoot(ref root) => Some(root),
 			_ => None,


### PR DESCRIPTION
This gets away the ugliness of using `DigestItem::Other` for seal.