### PR TITLE
Split casper function and data and add tests

### DIFF
--- a/casper/src/casper.rs
+++ b/casper/src/casper.rs
@@ -74,115 +74,131 @@ pub fn slashable<C: Attestation>(a: &C, b: &C) -> bool {
 	false
 }
 
-/// Casper struct holding pending attestation, justification and finalization information.
-pub struct Casper<A: Attestation> {
-	justification_bitfield: u64,
-	pending_attestations: Vec<A>,
-	epoch: A::Epoch,
-	justified_epoch: A::Epoch,
-	finalized_epoch: A::Epoch,
-	previous_justified_epoch: A::Epoch,
+/// Data needed for casper consensus.
+#[derive(Default, Clone, Eq, PartialEq)]
+pub struct CasperData<A: Attestation> {
+	/// Bitfield holding justification information.
+	pub justification_bitfield: u64,
+	/// Pending attestation to be processed.
+	pub pending_attestations: Vec<A>,
+	/// Current epoch.
+	pub epoch: A::Epoch,
+	/// Current justified epoch.
+	pub justified_epoch: A::Epoch,
+	/// Current finalized epoch.
+	pub finalized_epoch: A::Epoch,
+	/// Previous justified epoch.
+	pub previous_justified_epoch: A::Epoch,
 }
 
-impl<A: Attestation> Casper<A> {
+/// Casper struct holding pending attestation, justification and finalization information.
+pub struct Casper<'a, A: Attestation, S: ValidatorStore> {
+	data: CasperData<A>,
+	store: &'a S,
+}
+
+impl<'a, A, S> Casper<'a, A, S> where
+	A: Attestation,
+	S: ValidatorStore<ValidatorId=A::ValidatorId, Epoch=A::Epoch>,
+{
 	/// Get the current epoch.
 	pub fn current_epoch(&self) -> A::Epoch {
-		self.epoch
+		self.data.epoch
 	}
 
 	/// Get the next epoch.
 	pub fn next_epoch(&self) -> A::Epoch {
-		self.epoch + One::one()
+		self.data.epoch + One::one()
 	}
 
 	/// Get the previous epoch.
 	pub fn previous_epoch(&self) -> A::Epoch {
-		if self.epoch == Zero::zero() {
-			self.epoch
+		if self.data.epoch == Zero::zero() {
+			self.data.epoch
 		} else {
-			self.epoch - One::one()
+			self.data.epoch - One::one()
 		}
 	}
 
-	fn total_balance<S: ValidatorStore<ValidatorId=A::ValidatorId, Epoch=A::Epoch>>(&self, store: &S, epoch: A::Epoch) -> S::Balance {
-		let validators = store.active_validators(epoch);
-		store.total_balance(&validators)
+	fn total_balance(&self, epoch: A::Epoch) -> S::Balance {
+		let validators = self.store.active_validators(epoch);
+		self.store.total_balance(&validators)
 	}
 
-	fn attesting_balance<S: ValidatorStore<ValidatorId=A::ValidatorId, Epoch=A::Epoch>>(&self, store: &S, target_epoch: A::Epoch) -> S::Balance {
+	fn attesting_balance(&self, target_epoch: A::Epoch) -> S::Balance {
 		let mut validators = Vec::new();
-		for attestation in &self.pending_attestations {
+		for attestation in &self.data.pending_attestations {
 			if attestation.is_canon() && attestation.target_epoch() == target_epoch {
 				validators.push(attestation.validator_id().clone());
 			}
 		}
-		store.total_balance(&validators)
+		self.store.total_balance(&validators)
 	}
 
 	/// Get total balance of validators at current epoch.
-	pub fn current_total_balance<S: ValidatorStore<ValidatorId=A::ValidatorId, Epoch=A::Epoch>>(&self, store: &S) -> S::Balance {
-		self.total_balance(store, self.current_epoch())
+	pub fn current_total_balance(&self) -> S::Balance {
+		self.total_balance(self.current_epoch())
 	}
 
 	/// Get total balance of attesting validators at current epoch.
-	pub fn current_attesting_balance<S: ValidatorStore<ValidatorId=A::ValidatorId, Epoch=A::Epoch>>(&self, store: &S) -> S::Balance {
-		self.attesting_balance(store, self.current_epoch())
+	pub fn current_attesting_balance(&self) -> S::Balance {
+		self.attesting_balance(self.current_epoch())
 	}
 
 	/// Get total balance of validators at previous epoch.
-	pub fn previous_total_balance<S: ValidatorStore<ValidatorId=A::ValidatorId, Epoch=A::Epoch>>(&self, store: &S) -> S::Balance {
-		self.total_balance(store, self.previous_epoch())
+	pub fn previous_total_balance(&self) -> S::Balance {
+		self.total_balance(self.previous_epoch())
 	}
 
 	/// Get total balance of attesting validators at previous epoch.
-	pub fn previous_attesting_balance<S: ValidatorStore<ValidatorId=A::ValidatorId, Epoch=A::Epoch>>(&self, store: &S) -> S::Balance {
-		self.attesting_balance(store, self.previous_epoch())
+	pub fn previous_attesting_balance(&self) -> S::Balance {
+		self.attesting_balance(self.previous_epoch())
 	}
 
 	/// Push pending attestations to Casper.
 	pub fn push_pending_attestations(&mut self, mut attestations: Vec<A>) {
-		self.pending_attestations.append(&mut attestations);
+		self.data.pending_attestations.append(&mut attestations);
 	}
 
 	/// Prune pending attestation list.
 	pub fn prune_pending_attestations(&mut self) {
 		let current_epoch = self.current_epoch();
-		self.pending_attestations.retain(|attestation| {
+		self.data.pending_attestations.retain(|attestation| {
 			attestation.target_epoch() >= current_epoch
 		});
 	}
 
 	/// Advance the current epoch and start a new epoch.
-	pub fn advance_epoch<T: ValidatorStore<ValidatorId=A::ValidatorId, Epoch=A::Epoch>>(&mut self, store: &T) {
+	pub fn advance_epoch(&mut self) {
 		// Set justification status
-		let mut new_justified_epoch = self.justified_epoch;
-		self.justification_bitfield <<= 1;
-		if T::Balance::from(3u8) * self.previous_attesting_balance(store) >= T::Balance::from(2u8) * self.previous_total_balance(store) {
-			self.justification_bitfield |= 2;
+		let mut new_justified_epoch = self.data.justified_epoch;
+		self.data.justification_bitfield <<= 1;
+		if S::Balance::from(3u8) * self.previous_attesting_balance() >= S::Balance::from(2u8) * self.previous_total_balance() {
+			self.data.justification_bitfield |= 2;
 			new_justified_epoch = self.previous_epoch();
 		}
-		if T::Balance::from(3u8) * self.current_attesting_balance(store) >= T::Balance::from(2u8) * self.current_total_balance(store) {
-			self.justification_bitfield |= 1;
+		if S::Balance::from(3u8) * self.current_attesting_balance() >= S::Balance::from(2u8) * self.current_total_balance() {
+			self.data.justification_bitfield |= 1;
 			new_justified_epoch = self.current_epoch();
 		}
 
 		// Set finalization status
-		if (self.justification_bitfield >> 1) % 8 == 0b111 && self.previous_epoch() > One::one() && self.previous_justified_epoch == self.previous_epoch() - One::one() - One::one() {
-			self.finalized_epoch = self.previous_justified_epoch;
+		if (self.data.justification_bitfield >> 1) % 8 == 0b111 && self.previous_epoch() > One::one() && self.data.previous_justified_epoch == self.previous_epoch() - One::one() - One::one() {
+			self.data.finalized_epoch = self.data.previous_justified_epoch;
 		}
-		if (self.justification_bitfield >> 1) % 4 == 0b11 && self.previous_epoch() >= One::one() && self.previous_justified_epoch == self.previous_epoch() - One::one() {
-			self.finalized_epoch = self.previous_justified_epoch;
+		if (self.data.justification_bitfield >> 1) % 4 == 0b11 && self.previous_epoch() >= One::one() && self.data.previous_justified_epoch == self.previous_epoch() - One::one() {
+			self.data.finalized_epoch = self.data.previous_justified_epoch;
 		}
-		if (self.justification_bitfield >> 0) % 8 == 0b111 && self.previous_epoch() >= One::one() && self.justified_epoch == self.previous_epoch() - One::one() {
-			self.finalized_epoch = self.justified_epoch;
+		if (self.data.justification_bitfield >> 0) % 8 == 0b111 && self.previous_epoch() >= One::one() && self.data.justified_epoch == self.previous_epoch() - One::one() {
+			self.data.finalized_epoch = self.data.justified_epoch;
 		}
-		if (self.justification_bitfield >> 0) % 4 == 0b11 && self.justified_epoch == self.previous_epoch() {
-			self.finalized_epoch = self.justified_epoch;
+		if (self.data.justification_bitfield >> 0) % 4 == 0b11 && self.data.justified_epoch == self.previous_epoch() {
+			self.data.finalized_epoch = self.data.justified_epoch;
 		}
 
-		self.previous_justified_epoch = self.justified_epoch;
-		self.justified_epoch = new_justified_epoch;
-		self.epoch += One::one();
+		self.data.previous_justified_epoch = self.data.justified_epoch;
+		self.data.justified_epoch = new_justified_epoch;
+		self.data.epoch += One::one();
 
 		self.prune_pending_attestations();
 	}


### PR DESCRIPTION
Split casper into context and data. Add a test that contains four validators and four epoch advancement.