### PR TITLE
Cached SimpleSerialize: ShadowVec and ShadowTuple

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bs58"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3112,6 +3122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ssz-merkle"
+version = "0.1.0"
+dependencies = [
+ "bm 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssz 0.1.2",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4430,6 +4450,7 @@ dependencies = [
 "checksum block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 "checksum block-padding 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d75255892aeb580d3c566f213a2b6fdc1c66667839f45719ee1d30ebf2aea591"
 "checksum bls-aggregates 0.6.1 (git+https://github.com/sorpaas/signature-schemes)" = "<none>"
+"checksum bm 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "52b07b4407dd553801d4dc98d59e1e89fc974d01233a574fee6c265c9a66c26b"
 "checksum bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0de79cfb98e7aa9988188784d8664b4b5dad6eaaa0863b91d9a4ed871d4f7a42"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ members = [
 	"yamltests",
 	"utils/ssz",
 	"utils/ssz-derive",
+	"utils/ssz-merkle",
 	"utils/keccak-hasher",
 ]
 exclude = [

--- a/utils/ssz-merkle/Cargo.toml
+++ b/utils/ssz-merkle/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "ssz-merkle"
+version = "0.1.0"
+authors = ["Parity Team <admin@parity.io>"]
+description = "Merkle support for ssz."
+edition = "2018"
+
+[dependencies]
+bm = "0.1"
+digest = "0.8"
+generic-array = "0.12"
+ssz = { version = "0.1", path = "../ssz", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+	"ssz/std",
+]

--- a/utils/ssz-merkle/src/lib.rs
+++ b/utils/ssz-merkle/src/lib.rs
@@ -1,0 +1,168 @@
+use bm::{MerkleDB, MerkleVec, MerkleTuple, EndOf, IntermediateOf, IntermediateSizeOf, ValueOf};
+use ssz::Digestible;
+use generic_array::{GenericArray, ArrayLength};
+
+use core::marker::PhantomData;
+
+pub trait ShadowDB {
+	type KeySize: ArrayLength<u8>;
+	type Value;
+
+	fn get(&self, key: &GenericArray<u8, Self::KeySize>) -> Option<Self::Value>;
+	fn insert(&mut self, key: GenericArray<u8, Self::KeySize>, value: Self::Value);
+	fn remove(&mut self, key: &GenericArray<u8, Self::KeySize>) -> Option<Self::Value>;
+}
+
+pub struct ShadowVec<DB: MerkleDB, SDB: ShadowDB, T> {
+	vec: MerkleVec<DB>,
+	_marker: PhantomData<(SDB, T)>,
+}
+
+impl<DB: MerkleDB, SDB, T> ShadowVec<DB, SDB, T> where
+	EndOf<DB>: From<IntermediateOf<DB>> + Into<IntermediateOf<DB>> + From<usize> + Into<usize>,
+	SDB: ShadowDB<KeySize=IntermediateSizeOf<DB>, Value=T>,
+	T: Digestible<DB::Digest>,
+{
+    /// Push a new value to the vector.
+    pub fn push(&mut self, db: &mut DB, sdb: &mut SDB, value: T) {
+		let hashed = Digestible::<DB::Digest>::hash(&value);
+		sdb.insert(hashed.clone(), value);
+		self.vec.push(db, hashed.into());
+	}
+
+	/// Pop a value from the vector.
+    pub fn pop(&mut self, db: &mut DB, sdb: &mut SDB) -> Option<T> {
+		self.vec.pop(db).and_then(|hashed| {
+			sdb.remove(&hashed.into())
+		})
+    }
+
+	/// Set value at index.
+    pub fn set(&mut self, db: &mut DB, sdb: &mut SDB, index: usize, value: T) {
+		let hashed = Digestible::<DB::Digest>::hash(&value);
+		sdb.insert(hashed.clone(), value);
+		self.vec.set(db, index, hashed.into());
+    }
+
+	/// Get value at index.
+    pub fn get(&self, db: &DB, sdb: &SDB, index: usize) -> T {
+		let hashed = self.vec.get(db, index);
+		sdb.get(&hashed.into()).expect("Hash must exist")
+	}
+
+	/// Root of the current merkle vector.
+    pub fn root(&self) -> ValueOf<DB> {
+        self.vec.root()
+    }
+
+	/// Length of the vector.
+    pub fn len(&self) -> usize {
+        self.vec.len()
+    }
+
+    /// Create a new vector.
+    pub fn create(db: &mut DB) -> Self {
+		Self {
+			vec: MerkleVec::create(db),
+			_marker: PhantomData,
+		}
+    }
+
+    /// Drop the current vector.
+    pub fn drop(mut self, db: &mut DB, sdb: &mut SDB) {
+		while let Some(hashed) = self.vec.pop(db) {
+			sdb.remove(&hashed.into());
+		}
+		self.vec.drop(db)
+    }
+
+    /// Leak the current vector.
+    pub fn leak(self) -> (ValueOf<DB>, ValueOf<DB>, ValueOf<DB>, usize) {
+		self.vec.leak()
+    }
+
+    /// Initialize from a previously leaked one.
+    pub fn from_leaked(raw_root: ValueOf<DB>, tuple_root: ValueOf<DB>, empty_root: ValueOf<DB>, len: usize) -> Self {
+		Self {
+			vec: MerkleVec::from_leaked(raw_root, tuple_root, empty_root, len),
+			_marker: PhantomData,
+		}
+    }
+}
+
+pub struct ShadowTuple<DB: MerkleDB, SDB: ShadowDB, T> {
+	tuple: MerkleTuple<DB>,
+	_marker: PhantomData<(SDB, T)>,
+}
+
+impl<DB: MerkleDB, SDB, T> ShadowTuple<DB, SDB, T> where
+	EndOf<DB>: From<IntermediateOf<DB>> + Into<IntermediateOf<DB>>,
+	SDB: ShadowDB<KeySize=IntermediateSizeOf<DB>, Value=T>,
+	T: Digestible<DB::Digest>,
+{
+    /// Push a new value to the tuple.
+    pub fn push(&mut self, db: &mut DB, sdb: &mut SDB, value: T) {
+		let hashed = Digestible::<DB::Digest>::hash(&value);
+		sdb.insert(hashed.clone(), value);
+		self.tuple.push(db, hashed.into());
+	}
+
+	/// Pop a value from the tuple.
+    pub fn pop(&mut self, db: &mut DB, sdb: &mut SDB) -> Option<T> {
+		self.tuple.pop(db).and_then(|hashed| {
+			sdb.remove(&hashed.into())
+		})
+    }
+
+	/// Set value at index.
+    pub fn set(&mut self, db: &mut DB, sdb: &mut SDB, index: usize, value: T) {
+		let hashed = Digestible::<DB::Digest>::hash(&value);
+		sdb.insert(hashed.clone(), value);
+		self.tuple.set(db, index, hashed.into());
+    }
+
+	/// Get value at index.
+    pub fn get(&self, db: &DB, sdb: &SDB, index: usize) -> T {
+		let hashed = self.tuple.get(db, index);
+		sdb.get(&hashed.into()).expect("Hash must exist")
+	}
+
+	/// Root of the current merkle tuple.
+    pub fn root(&self) -> ValueOf<DB> {
+        self.tuple.root()
+    }
+
+	/// Length of the tuple.
+    pub fn len(&self) -> usize {
+        self.tuple.len()
+    }
+
+    /// Create a new tuple.
+    pub fn create(db: &mut DB) -> Self {
+		Self {
+			tuple: MerkleTuple::create(db, 0),
+			_marker: PhantomData,
+		}
+    }
+
+    /// Drop the current tuple.
+    pub fn drop(mut self, db: &mut DB, sdb: &mut SDB) {
+		while let Some(hashed) = self.tuple.pop(db) {
+			sdb.remove(&hashed.into());
+		}
+		self.tuple.drop(db)
+    }
+
+    /// Leak the current tuple.
+    pub fn leak(self) -> (ValueOf<DB>, ValueOf<DB>, usize) {
+		self.tuple.leak()
+    }
+
+    /// Initialize from a previously leaked one.
+    pub fn from_leaked(tuple_root: ValueOf<DB>, empty_root: ValueOf<DB>, len: usize) -> Self {
+		Self {
+			tuple: MerkleTuple::from_leaked(tuple_root, empty_root, len),
+			_marker: PhantomData,
+		}
+    }
+}


### PR DESCRIPTION
Initial integration of `bm` and `ssz`. This PR introduces `ShadowVec` and `ShadowTuple`. They represent a vector or a tuple that has subsequent SimpleSerialize values, where in the binary merkle, the top-level value hash is stored. The value is then stored in a `ShadowDB` through `hash -> value` pair.