### PR TITLE
ssz: add skip_default and no_bound attributes

### DIFF
--- a/utils/ssz-derive/src/encode.rs
+++ b/utils/ssz-derive/src/encode.rs
@@ -44,8 +44,13 @@ fn encode_fields<F>(
 	let recurse = fields.iter().enumerate().map(|(i, f)| {
 		let field = field_name(i, &f.ident);
 		let use_fixed = has_attr(&f.attrs, "use_fixed");
+		let skip = has_attr(&f.attrs, "skip_default");
 
-		if use_fixed {
+		if skip {
+			quote! {
+				();
+			}
+		} else if use_fixed {
 			decodable = false;
 			quote_spanned! { f.span() =>
 				::ssz::Encode::encode_to(&::ssz::Fixed(#field.as_ref()), #dest);

--- a/utils/ssz-derive/src/hash.rs
+++ b/utils/ssz-derive/src/hash.rs
@@ -28,9 +28,10 @@ fn encode_fields<F>(
 			false
 		};
 		let use_fixed = has_attr(&f.attrs, "use_fixed");
+		let skip = has_attr(&f.attrs, "skip_default");
 		let field = field_name(i, &f.ident);
 
-		if truncate {
+		if truncate || skip {
 			quote! { (); }
 		} else if use_fixed {
 			if is_digest {

--- a/utils/ssz-derive/src/prefixable.rs
+++ b/utils/ssz-derive/src/prefixable.rs
@@ -19,6 +19,7 @@ use syn::{
 	spanned::Spanned,
 	token::Comma,
 };
+use super::has_attr;
 
 type FieldsList = Punctuated<Field, Comma>;
 
@@ -30,11 +31,16 @@ fn encode_fields(
 
 	let recurse = fields.iter().map(|f| {
 		let ty = &f.ty;
+		let skip = has_attr(&f.attrs, "skip_default");
 
-		quote_spanned! { f.span() =>
-			{
-				use ::ssz::Prefixable;
-				#dest = #dest || <#ty>::prefixed();
+		if skip {
+			quote! { (); }
+		} else {
+			quote_spanned! {
+				f.span() => {
+					use ::ssz::Prefixable;
+					#dest = #dest || <#ty>::prefixed();
+				}
 			}
 		}
 	});

--- a/utils/ssz-derive/tests/mod.rs
+++ b/utils/ssz-derive/tests/mod.rs
@@ -20,6 +20,7 @@ extern crate ssz;
 extern crate ssz_derive;
 
 use core::fmt::Debug;
+use core::marker::PhantomData;
 use ssz::{Encode, Decode, Prefixable};
 
 fn assert_ed<T: Encode + Decode + Debug + PartialEq>(t: T, mut a: &[u8]) {
@@ -99,4 +100,32 @@ fn generic() {
 	assert_eq!(IndexedGeneric::<Vec<u8>, bool>::prefixed(), true);
 	assert_eq!(NamedGeneric::<bool, bool>::prefixed(), false);
 	assert_eq!(NamedGeneric::<Vec<u8>, bool>::prefixed(), true);
+}
+
+#[derive(Debug, PartialEq, Ssz)]
+#[ssz(no_bound(A))]
+struct Skipped<A> {
+	#[ssz(skip_default)]
+	_marker: PhantomData<A>
+}
+
+#[derive(Debug, PartialEq, Ssz)]
+#[ssz(no_bound(A))]
+struct Skipped2<A>(
+	#[ssz(skip_default)]
+	PhantomData<A>
+);
+
+#[test]
+fn skipped() {
+	let skipped = Skipped::<()> {
+		_marker: PhantomData,
+	};
+	let skipped2 = Skipped2::<()>(PhantomData);
+
+	let skipped_encode = skipped.encode();
+	let skipped2_encode = skipped2.encode();
+
+	assert_ed(skipped, &skipped_encode);
+	assert_ed(skipped2, &skipped2_encode);
 }


### PR DESCRIPTION
This makes handling generic for ssz encoding much easier. `skip_default` allows skipping encode/decode/hashing of a field entirely. On decoding, the default value is used. `no_bound` allows skipping adding bound traits for some bounds.