### PR TITLE
Properly use lmd-ghost fork choice for blockchain interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "blockchain"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -311,7 +311,7 @@ name = "blockchain-network-simple"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "blockchain 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2073,7 +2073,7 @@ dependencies = [
 name = "lmd-ghost"
 version = "0.1.0"
 dependencies = [
- "blockchain 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3211,7 +3211,7 @@ name = "shasper-blockchain"
 version = "0.1.0"
 dependencies = [
  "beacon 0.1.2",
- "blockchain 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "blockchain-network-simple 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5029,7 +5029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49665c62e0e700857531fa5d3763e91b539ff1abeebd56808d378b495870d60d"
 "checksum block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 "checksum block-padding 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d75255892aeb580d3c566f213a2b6fdc1c66667839f45719ee1d30ebf2aea591"
-"checksum blockchain 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "bf68e0de2b92f4416eb2e98e28ba297eb1d0eb8d79fa2a2d8236471e871880d3"
+"checksum blockchain 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "510b14ce6450e03c16952d6a3b29141b2f520c50f318ea918ce171c90008e7c3"
 "checksum blockchain-network-simple 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b744ca6248000fd35d0047b1c190bb0ee0b87994b0e52db69a3578a5f5aa9a98"
 "checksum bls-aggregates 0.6.1 (git+https://github.com/sorpaas/signature-schemes)" = "<none>"
 "checksum bm 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "52b07b4407dd553801d4dc98d59e1e89fc974d01233a574fee6c265c9a66c26b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "blockchain"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -311,7 +311,7 @@ name = "blockchain-network-simple"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "blockchain 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2073,7 +2073,7 @@ dependencies = [
 name = "lmd-ghost"
 version = "0.1.0"
 dependencies = [
- "blockchain 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3211,7 +3211,7 @@ name = "shasper-blockchain"
 version = "0.1.0"
 dependencies = [
  "beacon 0.1.2",
- "blockchain 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "blockchain-network-simple 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5029,7 +5029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49665c62e0e700857531fa5d3763e91b539ff1abeebd56808d378b495870d60d"
 "checksum block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 "checksum block-padding 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d75255892aeb580d3c566f213a2b6fdc1c66667839f45719ee1d30ebf2aea591"
-"checksum blockchain 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "510b14ce6450e03c16952d6a3b29141b2f520c50f318ea918ce171c90008e7c3"
+"checksum blockchain 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)" = "64981e4983d3cb63f3f7ed86e7a92693a7ad989ce74be78fd779dbe072749c45"
 "checksum blockchain-network-simple 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b744ca6248000fd35d0047b1c190bb0ee0b87994b0e52db69a3578a5f5aa9a98"
 "checksum bls-aggregates 0.6.1 (git+https://github.com/sorpaas/signature-schemes)" = "<none>"
 "checksum bm 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "52b07b4407dd553801d4dc98d59e1e89fc974d01233a574fee6c265c9a66c26b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,15 +303,15 @@ dependencies = [
 
 [[package]]
 name = "blockchain"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "blockchain-network-simple"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "blockchain 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2073,7 +2073,7 @@ dependencies = [
 name = "lmd-ghost"
 version = "0.1.0"
 dependencies = [
- "blockchain 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3211,9 +3211,10 @@ name = "shasper-blockchain"
 version = "0.1.0"
 dependencies = [
  "beacon 0.1.2",
- "blockchain 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "blockchain-network-simple 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain-network-simple 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lmd-ghost 0.1.0",
  "parity-codec 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ssz 0.1.2",
@@ -5029,8 +5030,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49665c62e0e700857531fa5d3763e91b539ff1abeebd56808d378b495870d60d"
 "checksum block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 "checksum block-padding 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d75255892aeb580d3c566f213a2b6fdc1c66667839f45719ee1d30ebf2aea591"
-"checksum blockchain 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)" = "64981e4983d3cb63f3f7ed86e7a92693a7ad989ce74be78fd779dbe072749c45"
-"checksum blockchain-network-simple 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b744ca6248000fd35d0047b1c190bb0ee0b87994b0e52db69a3578a5f5aa9a98"
+"checksum blockchain 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "7543ad5e02ee4fa104be6b3e054692bc9fe261d1bb700b504312c9ec4d35c1c1"
+"checksum blockchain-network-simple 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "215fe733a6cfd4662237adf2836664bd2708dcd97d0265923dc69fd0eea99170"
 "checksum bls-aggregates 0.6.1 (git+https://github.com/sorpaas/signature-schemes)" = "<none>"
 "checksum bm 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "52b07b4407dd553801d4dc98d59e1e89fc974d01233a574fee6c265c9a66c26b"
 "checksum bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0de79cfb98e7aa9988188784d8664b4b5dad6eaaa0863b91d9a4ed871d4f7a42"

--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 
 [dependencies]
 clap = "2.32"
+lmd-ghost = { path = "lmd-ghost" }
 beacon = { path = "../beacon" }
 parity-codec = { version = "3.0", features = ["derive"] }
 blockchain = "0.5"

--- a/blockchain/lmd-ghost/src/archive.rs
+++ b/blockchain/lmd-ghost/src/archive.rs
@@ -207,6 +207,7 @@ impl<E: BlockExecutor, Ba: Backend<Block=E::Block>> ImportBlock for ArchiveGhost
 	Ba: AncestorQuery,
 	Ba::Auxiliary: Auxiliary<E::Block>,
 	Ba::State: AsExternalities<E::Externalities>,
+	blockchain::chain::Error: From<Ba::Error> + From<E::Error>,
 {
 	type Block = Ba::Block;
 	type Error = blockchain::chain::Error;
@@ -233,9 +234,7 @@ impl<E: BlockExecutor, Ba: Backend<Block=E::Block>> ImportBlock for ArchiveGhost
 		if new_depth > current_best_depth {
 			importer.set_head(new_hash);
 		}
-		importer.commit().map_err(|e| {
-			blockchain::chain::Error::Backend(Box::new(e))
-		})?;
+		importer.commit()?;
 
 		Ok(())
 	}

--- a/blockchain/lmd-ghost/src/lib.rs
+++ b/blockchain/lmd-ghost/src/lib.rs
@@ -1,16 +1,23 @@
 pub mod archive;
 pub mod pruning;
 
-use blockchain::traits::Block;
+use blockchain::traits::{Block, BlockExecutor};
 use core::hash::Hash;
 
-pub trait LmdGhostExternalities<BI, VI> {
-	fn justified_active_validators(&self) -> Vec<VI>;
-	fn justified_block_id(&self) -> BI;
-}
+pub trait JustifiableExecutor: BlockExecutor {
+	type ValidatorIndex: Eq + Hash;
 
-pub trait VotedBlock: Block {
-	type ValidatorIdentifier: Eq + Hash;
-
-	fn votes(&self) -> Vec<(Self::ValidatorIdentifier, Self::Identifier)>;
+	fn justified_active_validators(
+		&self,
+		state: &mut Self::Externalities, // FIXME: replace `&mut` with `&`.
+	) -> Result<Vec<Self::ValidatorIndex>, Self::Error>;
+	fn justified_block_id(
+		&self,
+		state: &mut Self::Externalities, // FIXME: replace `&mut` with `&`.
+	) -> Result<<Self::Block as Block>::Identifier, Self::Error>;
+	fn votes(
+		&self,
+		block: &Self::Block,
+		state: &mut Self::Externalities, // FIXME: replace `&mut` with `&`.
+	) -> Result<Vec<(Self::ValidatorIndex, <Self::Block as Block>::Identifier)>, Self::Error>;
 }

--- a/blockchain/lmd-ghost/src/lib.rs
+++ b/blockchain/lmd-ghost/src/lib.rs
@@ -1,2 +1,16 @@
 pub mod archive;
 pub mod pruning;
+
+use blockchain::traits::Block;
+use core::hash::Hash;
+
+pub trait LmdGhostExternalities<BI, VI> {
+	fn justified_active_validators(&self) -> Vec<VI>;
+	fn justified_block_id(&self) -> BI;
+}
+
+pub trait VotedBlock: Block {
+	type ValidatorIdentifier: Eq + Hash;
+
+	fn votes(&self) -> Vec<(Self::ValidatorIdentifier, Self::Identifier)>;
+}

--- a/blockchain/src/main.rs
+++ b/blockchain/src/main.rs
@@ -1,8 +1,9 @@
 use beacon::{genesis, NoVerificationConfig};
 use beacon::types::Eth1Data;
 use blockchain::backend::{SharedBackend, MemoryBackend, MemoryLikeBackend};
-use blockchain_network_simple::{BestDepthImporter, BestDepthStatusProducer};
+use blockchain_network_simple::BestDepthStatusProducer;
 use shasper_blockchain::{Block, Executor, State};
+use lmd_ghost::archive::{NoCacheAncestorBackend, ArchiveGhostImporter};
 use clap::{App, Arg};
 
 fn main() {
@@ -20,12 +21,12 @@ fn main() {
 	).unwrap();
 	let genesis_block = Block(genesis_beacon_block);
 	let backend = SharedBackend::new(
-		MemoryBackend::<Block, (), State>::new_with_genesis(
+		NoCacheAncestorBackend::<MemoryBackend<Block, (), State>>::new_with_genesis(
 			genesis_block.clone(),
 			genesis_state.into(),
 		)
 	);
-	let importer = BestDepthImporter::new(Executor, backend.clone());
+	let importer = ArchiveGhostImporter::new(Executor, backend.clone());
 	let status = BestDepthStatusProducer::new(backend.clone());
 	let port = matches.value_of("port").unwrap_or("37365");
 


### PR DESCRIPTION
* Replaces `BestDepthImporter` with `ArchiveGhostImporter` in blockchain interface.
* Add necessary traits to query state internals for lmd-ghost via `JustifiableExecutor`.
* Update blockchain interface version.