### PR TITLE
transaction-pool: aggregate signatures when attestation data is the same

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 [[package]]
 name = "amcl"
 version = "0.1.0"
-source = "git+https://github.com/sigp/signature-schemes#ce83110748892919b62a0387f5a7f27d814dc796"
+source = "git+https://github.com/sigp/signature-schemes#54fef9183e130832a627f000cec9b0a20fb19f07"
 
 [[package]]
 name = "ansi_term"
@@ -322,8 +322,8 @@ dependencies = [
 
 [[package]]
 name = "bls-aggregates"
-version = "0.6.1"
-source = "git+https://github.com/sigp/signature-schemes#ce83110748892919b62a0387f5a7f27d814dc796"
+version = "0.7.0"
+source = "git+https://github.com/sigp/signature-schemes#54fef9183e130832a627f000cec9b0a20fb19f07"
 dependencies = [
  "amcl 0.1.0 (git+https://github.com/sigp/signature-schemes)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3223,7 +3223,7 @@ dependencies = [
  "beacon 0.1.2",
  "blockchain 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "blockchain-network-simple 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bls-aggregates 0.6.1 (git+https://github.com/sigp/signature-schemes)",
+ "bls-aggregates 0.7.0 (git+https://github.com/sigp/signature-schemes)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmd-ghost 0.1.0",
  "parity-codec 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3286,7 +3286,7 @@ name = "shasper-crypto"
 version = "0.1.0"
 dependencies = [
  "beacon 0.1.2",
- "bls-aggregates 0.6.1 (git+https://github.com/sigp/signature-schemes)",
+ "bls-aggregates 0.7.0 (git+https://github.com/sigp/signature-schemes)",
 ]
 
 [[package]]
@@ -4971,7 +4971,7 @@ name = "yaml-rust"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5058,7 +5058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum block-padding 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d75255892aeb580d3c566f213a2b6fdc1c66667839f45719ee1d30ebf2aea591"
 "checksum blockchain 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5ea0d0eff2a749475e9e1d481085739f7ca8d64f83f53eedfbf0b717a871196e"
 "checksum blockchain-network-simple 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "54945f05488ffd39e45588f77e92f255b6dbd4ee06641746f4ba77afef6dd672"
-"checksum bls-aggregates 0.6.1 (git+https://github.com/sigp/signature-schemes)" = "<none>"
+"checksum bls-aggregates 0.7.0 (git+https://github.com/sigp/signature-schemes)" = "<none>"
 "checksum bm 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "52b07b4407dd553801d4dc98d59e1e89fc974d01233a574fee6c265c9a66c26b"
 "checksum bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0de79cfb98e7aa9988188784d8664b4b5dad6eaaa0863b91d9a4ed871d4f7a42"
 "checksum bumpalo 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4639720be048090544634e0402490838995ccdc9d2fe648f528f30d3c33ae71f"

--- a/beacon/src/config.rs
+++ b/beacon/src/config.rs
@@ -31,6 +31,8 @@ pub trait BLSVerification {
 	fn verify(pubkey: &ValidatorId, message: &H256, signature: &Signature, domain: u64) -> bool;
 	/// Aggregate BLS public keys.
 	fn aggregate_pubkeys(pubkeys: &[ValidatorId]) -> ValidatorId;
+	/// Aggregate BLS signatures.
+	fn aggregate_signatures(signatures: &[Signature]) -> Signature;
 	/// Verify multiple BLS signatures.
 	fn verify_multiple(pubkeys: &[ValidatorId], messages: &[H256], signature: &Signature, domain: u64) -> bool;
 }
@@ -46,6 +48,9 @@ impl BLSVerification for BLSNoVerification {
 	}
 	fn aggregate_pubkeys(_pubkeys: &[ValidatorId]) -> ValidatorId {
 		ValidatorId::default()
+	}
+	fn aggregate_signatures(_signatures: &[Signature]) -> Signature {
+		Signature::default()
 	}
 	fn verify_multiple(_pubkeys: &[ValidatorId], _messages: &[H256], _signature: &Signature, _domain: u64) -> bool {
 		true
@@ -178,6 +183,8 @@ pub trait Config {
 	) -> bool;
 	/// Aggregate BLS public keys.
 	fn bls_aggregate_pubkeys(&self, pubkeys: &[ValidatorId]) -> ValidatorId;
+	/// Aggregate BLS signatures.
+	fn aggregate_signatures(signatures: &[Signature]) -> Signature;
 	/// Verify multiple BLS signatures.
 	fn bls_verify_multiple(
 		&self,
@@ -437,6 +444,9 @@ impl<BLS: BLSVerification> Config for ParameteredConfig<BLS> {
 	}
 	fn bls_aggregate_pubkeys(&self, pubkeys: &[ValidatorId]) -> ValidatorId {
 		BLS::aggregate_pubkeys(pubkeys)
+	}
+	fn aggregate_signatures(signatures: &[Signature]) -> Signature {
+		BLS::aggregate_signatures(signatures)
 	}
 	fn bls_verify_multiple(&self, pubkeys: &[ValidatorId], messages: &[H256], signature: &Signature, domain: u64) -> bool {
 		BLS::verify_multiple(pubkeys, messages, signature, domain)

--- a/beacon/src/primitives/bitfield.rs
+++ b/beacon/src/primitives/bitfield.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
+use core::ops::{BitOr, BitOrAssign, BitAnd, BitAndAssign};
+use core::cmp::min;
 #[cfg(feature = "parity-codec")]
 use codec::{Encode, Decode};
 #[cfg(feature = "serde")]
@@ -75,6 +77,40 @@ impl<D: digest::Digest> ssz::Digestible<D> for BitField {
 	}
 }
 
+impl BitOr for BitField {
+	type Output = Self;
+
+	fn bitor(mut self, rhs: Self) -> Self {
+		self.bitor_assign(rhs);
+		self
+	}
+}
+
+impl BitOrAssign for BitField {
+	fn bitor_assign(&mut self, rhs: Self) {
+		for i in 0..min(self.0.len(), rhs.0.len()) {
+			self.0[i] |= rhs.0[i];
+		}
+	}
+}
+
+impl BitAnd for BitField {
+	type Output = Self;
+
+	fn bitand(mut self, rhs: Self) -> Self {
+		self.bitand_assign(rhs);
+		self
+	}
+}
+
+impl BitAndAssign for BitField {
+	fn bitand_assign(&mut self, rhs: Self) {
+		for i in 0..min(self.0.len(), rhs.0.len()) {
+			self.0[i] &= rhs.0[i];
+		}
+	}
+}
+
 impl BitField {
 	/// New with given length.
 	pub fn new(length: usize) -> Self {
@@ -86,7 +122,7 @@ impl BitField {
 
 	/// Get bit at index.
 	pub fn get_bit(&self, index: usize) -> bool {
-		(self.0[index / 8] >> (index % 8)) == 1
+		(self.0[index / 8] >> (index % 8)) % 2 == 1
 	}
 
 	/// Set bit at index.

--- a/blockchain/src/lib.rs
+++ b/blockchain/src/lib.rs
@@ -1,3 +1,7 @@
+mod pool;
+
+pub use pool::AttestationPool;
+
 use beacon::primitives::H256;
 use beacon::types::{BeaconState, BeaconBlock, UnsealedBeaconBlock, BeaconBlockHeader};
 use beacon::{Error as BeaconError, Executive, Config, Inherent, Transaction};

--- a/blockchain/src/pool.rs
+++ b/blockchain/src/pool.rs
@@ -1,0 +1,53 @@
+use beacon::Config;
+use beacon::primitives::H256;
+use beacon::types::{Attestation, AttestationDataAndCustodyBit};
+use ssz::Digestible;
+use std::collections::HashMap;
+
+pub struct AttestationPool<'config, C: Config> {
+	pool: HashMap<H256, Attestation>,
+	_config: &'config C,
+}
+
+impl<'config, C: Config> AttestationPool<'config, C> {
+	pub fn new(_config: &'config C) -> Self {
+		Self {
+			pool: Default::default(),
+			_config,
+		}
+	}
+
+	pub fn push(&mut self, attestation: Attestation) {
+		let hash = H256::from_slice(Digestible::<C::Digest>::hash(&AttestationDataAndCustodyBit {
+			data: attestation.data.clone(),
+			custody_bit: false,
+		}).as_slice());
+
+		self.pool.entry(hash)
+			.and_modify(|existing| {
+				// TODO: Handle cases for duplicate signatures.
+				for i in 0..(existing.aggregation_bitfield.0.len() * 8) {
+					if attestation.aggregation_bitfield.get_bit(i) {
+						assert_eq!(existing.aggregation_bitfield.get_bit(i), false);
+					}
+				}
+				existing.aggregation_bitfield |= attestation.aggregation_bitfield.clone();
+				for i in 0..attestation.custody_bitfield.0.len() {
+					assert_eq!(attestation.custody_bitfield.0[i], 0);
+				}
+				existing.custody_bitfield |= attestation.custody_bitfield.clone();
+				existing.signature = C::aggregate_signatures(&[
+					existing.signature, attestation.signature.clone()
+				]);
+			})
+			.or_insert(attestation);
+    }
+
+	pub fn pop(&mut self, key: &H256) {
+		self.pool.remove(key);
+	}
+
+	pub fn iter(&self) -> impl Iterator<Item=(&H256, &Attestation)> {
+		self.pool.iter()
+	}
+}

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -51,11 +51,11 @@ pub mod bls {
 
 		impl BLSVerification for Verification {
 			fn verify(pubkey: &ValidatorId, message: &H256, signature: &Signature, domain: u64) -> bool {
-				let pubkey = match bls::Public::from_bytes(&pubkey[..]) {
+				let pubkey = match bls::AggregatePublic::from_bytes(&pubkey[..]) {
 					Ok(value) => value,
 					Err(_) => return false,
 				};
-				let signature = match bls::Signature::from_bytes(&signature[..]) {
+				let signature = match bls::AggregateSignature::from_bytes(&signature[..]) {
 					Ok(value) => value,
 					Err(_) => return false,
 				};
@@ -71,6 +71,17 @@ pub mod bls {
 					aggregated.add(&pubkey);
 				}
 				ValidatorId::from_slice(&aggregated.as_bytes()[..])
+			}
+			fn aggregate_signatures(signatures: &[Signature]) -> Signature {
+				let mut aggregated = bls::AggregateSignature::new();
+				for signature in signatures {
+					let signature = match bls::Signature::from_bytes(&signature[..]) {
+						Ok(value) => value,
+						Err(_) => return Signature::default(),
+					};
+					aggregated.add(&signature);
+				}
+				Signature::from_slice(&aggregated.as_bytes()[..])
 			}
 			fn verify_multiple(pubkeys: &[ValidatorId], messages: &[H256], signature: &Signature, domain: u64) -> bool {
 				let mut bls_messages = Vec::new();


### PR DESCRIPTION
When an attestation enters transaction pool, check whether the attestation data is existing. If so, we aggregate signatures to save space.