### PR TITLE
Remove ImportAction::swap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "blockchain"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -312,7 +312,7 @@ name = "blockchain-network-simple"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "blockchain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2088,7 +2088,7 @@ dependencies = [
 name = "lmd-ghost"
 version = "0.1.0"
 dependencies = [
- "blockchain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3225,7 +3225,7 @@ name = "shasper-blockchain"
 version = "0.1.0"
 dependencies = [
  "beacon 0.1.2",
- "blockchain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "blockchain-network-simple 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bls-aggregates 0.7.0 (git+https://github.com/sigp/signature-schemes)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5061,7 +5061,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49665c62e0e700857531fa5d3763e91b539ff1abeebd56808d378b495870d60d"
 "checksum block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 "checksum block-padding 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d75255892aeb580d3c566f213a2b6fdc1c66667839f45719ee1d30ebf2aea591"
-"checksum blockchain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "76c8cc2faad7a76b764d73b83ccb44f64d0f41e451e0e856a6a0bd4c34dae6a8"
+"checksum blockchain 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "56ceac13dde1806663ead24eef44c13c209335050dc8c6218aee7fa203d75b1b"
 "checksum blockchain-network-simple 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d594f7462ba67468a27a5609c9cd63f52bf27f3ac6b2d2b8771203f819ad187c"
 "checksum bls-aggregates 0.7.0 (git+https://github.com/sigp/signature-schemes)" = "<none>"
 "checksum bm 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "52b07b4407dd553801d4dc98d59e1e89fc974d01233a574fee6c265c9a66c26b"


### PR DESCRIPTION
This fixes the ugly `ImportAction::swap`, which was there for backend type conversion.