### PR TITLE
Overhaul backend interface design

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,15 +304,15 @@ dependencies = [
 
 [[package]]
 name = "blockchain"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "blockchain-network-simple"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "blockchain 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2088,7 +2088,7 @@ dependencies = [
 name = "lmd-ghost"
 version = "0.1.0"
 dependencies = [
- "blockchain 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3225,8 +3225,8 @@ name = "shasper-blockchain"
 version = "0.1.0"
 dependencies = [
  "beacon 0.1.2",
- "blockchain 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "blockchain-network-simple 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blockchain-network-simple 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bls-aggregates 0.7.0 (git+https://github.com/sigp/signature-schemes)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmd-ghost 0.1.0",
@@ -5061,8 +5061,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49665c62e0e700857531fa5d3763e91b539ff1abeebd56808d378b495870d60d"
 "checksum block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 "checksum block-padding 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d75255892aeb580d3c566f213a2b6fdc1c66667839f45719ee1d30ebf2aea591"
-"checksum blockchain 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "56ceac13dde1806663ead24eef44c13c209335050dc8c6218aee7fa203d75b1b"
-"checksum blockchain-network-simple 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d594f7462ba67468a27a5609c9cd63f52bf27f3ac6b2d2b8771203f819ad187c"
+"checksum blockchain 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bcdc104c69f558c4701f2fc2bb1fcd2d87aaefab3a9cb6b3701cf28a4d410637"
+"checksum blockchain-network-simple 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "93673d2d54d658828e1c0a1ebd58bea1cbb66b6abd78bc1e3f84f3c511f2dc57"
 "checksum bls-aggregates 0.7.0 (git+https://github.com/sigp/signature-schemes)" = "<none>"
 "checksum bm 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "52b07b4407dd553801d4dc98d59e1e89fc974d01233a574fee6c265c9a66c26b"
 "checksum bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0de79cfb98e7aa9988188784d8664b4b5dad6eaaa0863b91d9a4ed871d4f7a42"

--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -11,8 +11,8 @@ lmd-ghost = { path = "lmd-ghost" }
 beacon = { path = "../beacon" }
 parity-codec = { version = "3.0", features = ["derive"] }
 crypto = { package = "shasper-crypto", path = "../crypto" }
-blockchain = "0.7"
-blockchain-network-simple = "0.3"
+blockchain = "0.8"
+blockchain-network-simple = "0.4"
 ssz = { path = "../utils/ssz" }
 sha2 = "0.8"
 bls-aggregates = { git = "https://github.com/sigp/signature-schemes" }

--- a/blockchain/lmd-ghost/Cargo.toml
+++ b/blockchain/lmd-ghost/Cargo.toml
@@ -6,4 +6,4 @@ description = "Cached LMD Ghost implementation"
 edition = "2018"
 
 [dependencies]
-blockchain = "0.7"
+blockchain = "0.8"

--- a/blockchain/src/backend.rs
+++ b/blockchain/src/backend.rs
@@ -1,0 +1,104 @@
+use blockchain::traits::{Block, Auxiliary};
+use blockchain::backend::{Store, SharedCommittable, ChainQuery, Operation};
+use lmd_ghost::archive::{AncestorQuery, NoCacheAncestorQuery};
+
+pub struct ShasperBackend<Ba>(Ba);
+
+impl<Ba> ShasperBackend<Ba> {
+	pub fn new(backend: Ba) -> Self {
+		Self(backend)
+	}
+}
+
+impl<Ba: Clone> Clone for ShasperBackend<Ba> {
+	fn clone(&self) -> Self {
+		Self(self.0.clone())
+	}
+}
+
+impl<Ba: Store> Store for ShasperBackend<Ba> {
+	type Block = Ba::Block;
+	type State = Ba::State;
+	type Auxiliary = Ba::Auxiliary;
+	type Error = Ba::Error;
+}
+
+impl<Ba: ChainQuery> ChainQuery for ShasperBackend<Ba> {
+	fn genesis(&self) -> <Self::Block as Block>::Identifier {
+		self.0.genesis()
+	}
+	fn head(&self) -> <Self::Block as Block>::Identifier {
+		self.0.head()
+	}
+	fn contains(
+		&self,
+		hash: &<Self::Block as Block>::Identifier,
+	) -> Result<bool, Self::Error> {
+		Ok(self.0.contains(hash)?)
+	}
+	fn is_canon(
+		&self,
+		hash: &<Self::Block as Block>::Identifier,
+	) -> Result<bool, Self::Error> {
+		Ok(self.0.is_canon(hash)?)
+	}
+	fn lookup_canon_depth(
+		&self,
+		depth: usize,
+	) -> Result<Option<<Self::Block as Block>::Identifier>, Self::Error> {
+		Ok(self.0.lookup_canon_depth(depth)?)
+	}
+	fn auxiliary(
+		&self,
+		key: &<Self::Auxiliary as Auxiliary<Self::Block>>::Key,
+	) -> Result<Option<Self::Auxiliary>, Self::Error> {
+		Ok(self.0.auxiliary(key)?)
+	}
+	fn depth_at(
+		&self,
+		hash: &<Self::Block as Block>::Identifier,
+	) -> Result<usize, Self::Error> {
+		Ok(self.0.depth_at(hash)?)
+	}
+	fn children_at(
+		&self,
+		hash: &<Self::Block as Block>::Identifier,
+	) -> Result<Vec<<Self::Block as Block>::Identifier>, Self::Error> {
+		Ok(self.0.children_at(hash)?)
+	}
+	fn state_at(
+		&self,
+		hash: &<Self::Block as Block>::Identifier,
+	) -> Result<Self::State, Self::Error> {
+		Ok(self.0.state_at(hash)?)
+	}
+	fn block_at(
+		&self,
+		hash: &<Self::Block as Block>::Identifier,
+	) -> Result<Self::Block, Self::Error> {
+		Ok(self.0.block_at(hash)?)
+	}
+}
+
+impl<Ba: ChainQuery> AncestorQuery for ShasperBackend<Ba> {
+	fn ancestor_at(
+		&self,
+		id: &<Self::Block as Block>::Identifier,
+		depth: usize
+	) -> Result<<Self::Block as Block>::Identifier, Self::Error> {
+		NoCacheAncestorQuery::new(&self.0).ancestor_at(id, depth)
+	}
+}
+
+impl<Ba> SharedCommittable for ShasperBackend<Ba> where
+	Ba: SharedCommittable<Operation=Operation<Self::Block, Self::State, Self::Auxiliary>>
+{
+	type Operation = Operation<Self::Block, Self::State, Self::Auxiliary>;
+
+	fn commit(
+		&self,
+		operation: Operation<Self::Block, Self::State, Self::Auxiliary>,
+	) -> Result<(), Self::Error> {
+		self.0.commit(operation)
+	}
+}

--- a/blockchain/src/lib.rs
+++ b/blockchain/src/lib.rs
@@ -1,5 +1,6 @@
 mod pool;
 pub mod rocksdb;
+pub mod backend;
 
 pub use pool::AttestationPool;
 


### PR DESCRIPTION
Prefer composition over inheritance for backend function separation to simplify the design.

* Underlying database defines its own "settlement" type, which can be called by an operation to commit a database transaction. This makes backend atomic, while also extensible for operations that it can support.
* End users are expected to "compose" multiple backend types that he or she wants to support for query and commitment. For convenience, the traits are defined again.