### PR TITLE
Update spec from v0.6.1 to v0.6.3

### DIFF
--- a/beacon/src/executive/helpers/mod.rs
+++ b/beacon/src/executive/helpers/mod.rs
@@ -188,6 +188,8 @@ impl<'state, 'config, C: Config> Executive<'state, 'config, C> {
 	pub(crate) fn crosslink_committee(
 		&self, epoch: Epoch, shard: Shard
 	) -> Result<Vec<ValidatorIndex>, Error> {
+		// `compute_committee` is inlined here because it's only used once.
+
 		let indices = self.active_validator_indices(epoch);
 		let seed = self.generate_seed(epoch);
 		let index = (shard +

--- a/beacon/src/executive/transition/per_block/operations/attester_slashing.rs
+++ b/beacon/src/executive/transition/per_block/operations/attester_slashing.rs
@@ -47,6 +47,7 @@ impl<'state, 'config, C: Config> Executive<'state, 'config, C> {
 				full.push(index);
 			}
 		}
+		full.sort();
 
 		for index in full {
 			if self.state.validator_registry[index as usize]

--- a/beacon/src/executive/transition/per_block/operations/deposit.rs
+++ b/beacon/src/executive/transition/per_block/operations/deposit.rs
@@ -46,6 +46,9 @@ impl<'state, 'config, C: Config> Executive<'state, 'config, C> {
 			.map(|v| v.pubkey.clone()).collect::<Vec<_>>();
 
 		if !validator_pubkeys.contains(&pubkey) {
+			// Verify the deposit signature (proof of possession). Invalid
+			// signatures are allowed by the deposit contract, and hence
+			// included on-chain, but must not be processed.
 			if !self.config.bls_verify(
 				&pubkey,
 				&H256::from_slice(

--- a/beacon/src/lib.rs
+++ b/beacon/src/lib.rs
@@ -37,6 +37,11 @@ use crate::prelude::*;
 #[cfg(feature = "parity-codec")]
 extern crate parity_codec as codec;
 
+/// Version of ethereum/eth2.0-specs.
+pub const VERSION = "v0.6.3";
+/// Commit of ethereum/eth2.0-specs.
+pub const COMMIT = "cb9301a9fece8864d97b6ff6b0bb3a662fa21484";
+
 mod config;
 mod utils;
 mod error;

--- a/beacon/src/lib.rs
+++ b/beacon/src/lib.rs
@@ -38,9 +38,9 @@ use crate::prelude::*;
 extern crate parity_codec as codec;
 
 /// Version of ethereum/eth2.0-specs.
-pub const VERSION = "v0.6.3";
+pub const VERSION: &str = "v0.6.3";
 /// Commit of ethereum/eth2.0-specs.
-pub const COMMIT = "cb9301a9fece8864d97b6ff6b0bb3a662fa21484";
+pub const COMMIT: &str = "cb9301a9fece8864d97b6ff6b0bb3a662fa21484";
 
 mod config;
 mod utils;


### PR DESCRIPTION
Fixes #149 

Based on diff https://github.com/ethereum/eth2.0-specs/compare/v0.6.1...v0.6.3
The `full.sorted()` line looks like the only change made to spec.