### PR TITLE
Update spec test to v0.6.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,8 +189,8 @@ dependencies = [
  "impl-serde 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ssz 0.1.2",
  "ssz-derive 0.1.2",
@@ -397,8 +397,8 @@ dependencies = [
  "parity-codec 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "plain_hasher 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1159,7 +1159,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1211,8 +1211,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1247,7 +1247,7 @@ dependencies = [
  "jsonrpc-core 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2421,7 +2421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2456,7 +2456,7 @@ dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multihash 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2471,7 +2471,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multihash 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3110,12 +3110,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.85"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.85"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3130,7 +3130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3140,7 +3140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3308,8 +3308,8 @@ dependencies = [
  "parity-codec 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "shasper-crypto 0.1.0",
  "ssz 0.1.2",
  "ssz-derive 0.1.2",
@@ -3329,8 +3329,8 @@ dependencies = [
  "parity-codec-derive 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "shasper-consensus-primitives 0.1.0",
  "shasper-crypto 0.1.0",
  "shasper-primitives 0.1.0",
@@ -3391,7 +3391,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3479,8 +3479,8 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-io 0.1.0 (git+https://github.com/paritytech/substrate)",
  "sr-std 0.1.0 (git+https://github.com/paritytech/substrate)",
  "substrate-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
@@ -3501,8 +3501,8 @@ source = "git+https://github.com/paritytech/substrate#91fa6594fe734ae41a2019cbc2
 dependencies = [
  "impl-serde 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
  "sr-std 0.1.0 (git+https://github.com/paritytech/substrate)",
 ]
@@ -3513,8 +3513,8 @@ version = "0.1.0"
 source = "git+https://github.com/paritytech/substrate#91fa6594fe734ae41a2019cbc277cd175e7e91b9"
 dependencies = [
  "parity-codec 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-std 0.1.0 (git+https://github.com/paritytech/substrate)",
  "substrate-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
 ]
@@ -3529,8 +3529,8 @@ dependencies = [
  "once_cell 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "paste 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-io 0.1.0 (git+https://github.com/paritytech/substrate)",
  "sr-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
@@ -3641,8 +3641,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3654,8 +3654,8 @@ dependencies = [
  "base-x 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.31 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3872,8 +3872,8 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-io 0.1.0 (git+https://github.com/paritytech/substrate)",
  "sr-version 0.1.0 (git+https://github.com/paritytech/substrate)",
  "substrate-panic-handler 0.1.0 (git+https://github.com/paritytech/substrate)",
@@ -3915,8 +3915,8 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-crypto 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
  "subtle 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3963,8 +3963,8 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4003,8 +4003,8 @@ dependencies = [
  "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "schnorrkel 0.1.0 (git+https://github.com/w3f/schnorrkel)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-std 0.1.0 (git+https://github.com/paritytech/substrate)",
  "substrate-bip39 0.2.0 (git+https://github.com/paritytech/substrate-bip39)",
@@ -4026,8 +4026,8 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
  "sr-version 0.1.0 (git+https://github.com/paritytech/substrate)",
@@ -4049,7 +4049,7 @@ dependencies = [
  "jsonrpc-pubsub 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-ws-server 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
  "substrate-rpc 0.1.0 (git+https://github.com/paritytech/substrate)",
 ]
@@ -4059,7 +4059,7 @@ name = "substrate-serializer"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/substrate#91fa6594fe734ae41a2019cbc277cd175e7e91b9"
 dependencies = [
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4075,8 +4075,8 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-io 0.1.0 (git+https://github.com/paritytech/substrate)",
@@ -4133,8 +4133,8 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-json 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4151,8 +4151,8 @@ dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 0.1.0 (git+https://github.com/paritytech/substrate)",
 ]
 
@@ -4530,7 +4530,7 @@ name = "toml"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4985,9 +4985,10 @@ version = "0.1.0"
 dependencies = [
  "beacon 0.1.2",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shasper-crypto 0.1.0",
  "ssz 0.1.2",
 ]
 
@@ -5338,8 +5339,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum send_wrapper 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0eddf2e8f50ced781f288c19f18621fa72a3779e3cb58dbf23b07469b0abeb4"
-"checksum serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)" = "534b8b91a95e0f71bca3ed5824752d558da048d4248c91af873b63bd60519752"
-"checksum serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)" = "a915306b0f1ac5607797697148c223bedeaa36bcc2e28a01441cd638cc6567b4"
+"checksum serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)" = "32746bf0f26eab52f06af0d0aa1984f641341d06d8d673c693871da2d188c9be"
+"checksum serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)" = "46a3223d0c9ba936b61c0d2e3e559e3217dbfb8d65d06d26e8b3c25de38bae3e"
 "checksum serde_json 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "4b90a9fbe1211e57d3e1c15670f1cb00802988fb23a1a4aad7a2b63544f1920e"
 "checksum serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0887a8e097a69559b56aa2526bf7aff7c3048cf627dff781f0b56a6001534593"
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"

--- a/beacon/src/config.rs
+++ b/beacon/src/config.rs
@@ -25,6 +25,12 @@ use digest::Digest;
 use crate::primitives::{H256, Uint, Epoch, Slot, ValidatorIndex, Signature, ValidatorId};
 use crate::utils::to_uint;
 
+/// Traits that allows creation from any other config.
+pub trait FromConfig {
+	/// Create self from another config.
+	fn from_config<C: Config>(config: &C) -> Self;
+}
+
 /// BLS operations
 pub trait BLSVerification {
 	/// Verify BLS signature.
@@ -450,6 +456,68 @@ impl<BLS: BLSVerification> Config for ParameteredConfig<BLS> {
 	}
 	fn bls_verify_multiple(&self, pubkeys: &[ValidatorId], messages: &[H256], signature: &Signature, domain: u64) -> bool {
 		BLS::verify_multiple(pubkeys, messages, signature, domain)
+	}
+}
+
+impl<BLS: BLSVerification> FromConfig for ParameteredConfig<BLS> {
+	fn from_config<C: Config>(config: &C) -> Self {
+		Self {
+			shard_count: config.shard_count(),
+			target_committee_size: config.target_committee_size(),
+			max_indices_per_attestation: config.max_indices_per_attestation(),
+			min_per_epoch_churn_limit: config.min_per_epoch_churn_limit(),
+			churn_limit_quotient: config.churn_limit_quotient(),
+			base_rewards_per_epoch: config.base_rewards_per_epoch(),
+			shuffle_round_count: config.shuffle_round_count(),
+
+			deposit_contract_tree_depth: config.deposit_contract_tree_depth(),
+
+			min_deposit_amount: config.min_deposit_amount(),
+			max_effective_balance: config.max_effective_balance(),
+			ejection_balance: config.ejection_balance(),
+			effective_balance_increment: config.effective_balance_increment(),
+
+			genesis_slot: config.genesis_slot(),
+			genesis_epoch: config.genesis_epoch(),
+			bls_withdrawal_prefix_byte: [config.bls_withdrawal_prefix_byte()],
+
+			min_attestation_inclusion_delay: config.min_attestation_inclusion_delay(),
+			slots_per_epoch: config.slots_per_epoch(),
+			min_seed_lookahead: config.min_seed_lookahead(),
+			activation_exit_delay: config.activation_exit_delay(),
+			slots_per_eth1_voting_period: config.slots_per_eth1_voting_period(),
+			slots_per_historical_root: config.slots_per_historical_root(),
+			min_validator_withdrawability_delay: config.min_validator_withdrawability_delay(),
+			persistent_committee_period: config.persistent_committee_period(),
+			max_crosslink_epochs: config.max_crosslink_epochs(),
+			min_epochs_to_inactivity_penalty: config.min_epochs_to_inactivity_penalty(),
+
+			latest_randao_mixes_length: config.latest_randao_mixes_length(),
+			latest_active_index_roots_length: config.latest_active_index_roots_length(),
+			latest_slashed_exit_length: config.latest_slashed_exit_length(),
+
+			base_reward_quotient: config.base_reward_quotient(),
+			whistleblowing_reward_quotient: config.whistleblowing_reward_quotient(),
+			proposer_reward_quotient: config.proposer_reward_quotient(),
+			inactivity_penalty_quotient: config.inactivity_penalty_quotient(),
+			min_slashing_penalty_quotient: config.min_slashing_penalty_quotient(),
+
+			max_proposer_slashings: config.max_proposer_slashings(),
+			max_attester_slashings: config.max_attester_slashings(),
+			max_attestations: config.max_attestations(),
+			max_deposits: config.max_deposits(),
+			max_voluntary_exits: config.max_voluntary_exits(),
+			max_transfers: config.max_transfers(),
+
+			domain_beacon_proposer: config.domain_beacon_proposer(),
+			domain_randao: config.domain_randao(),
+			domain_attestation: config.domain_attestation(),
+			domain_deposit: config.domain_deposit(),
+			domain_voluntary_exit: config.domain_voluntary_exit(),
+			domain_transfer: config.domain_transfer(),
+
+			_marker: PhantomData,
+		}
 	}
 }
 

--- a/beacon/src/error.rs
+++ b/beacon/src/error.rs
@@ -54,6 +54,8 @@ pub enum Error {
 	BlockSignatureInvalid,
 	/// Randao signature is invalid.
 	RandaoSignatureInvalid,
+	/// Proposer slashing contains invalid proposer index.
+	ProposerSlashingInvalidProposerIndex,
 	/// Proposer slashing contains invalid slot.
 	ProposerSlashingInvalidSlot,
 	/// Proposer slashing is on same header.

--- a/beacon/src/executive/mod.rs
+++ b/beacon/src/executive/mod.rs
@@ -38,8 +38,8 @@ pub struct Executive<'state, 'config, C: Config> {
 	pub config: &'config C,
 }
 
-/// Given a block, execute based on a parent state.
-pub fn execute_block<C: Config>(block: &BeaconBlock, state: &mut BeaconState, config: &C) -> Result<(), Error> {
+/// Execute a block without verifying the state root.
+pub fn execute_block_no_verify_state_root<C: Config>(block: &BeaconBlock, state: &mut BeaconState, config: &C) -> Result<(), Error> {
 	let mut executive = Executive {
 		state, config
 	};
@@ -111,6 +111,17 @@ pub fn execute_block<C: Config>(block: &BeaconBlock, state: &mut BeaconState, co
 	for transfer in &block.body.transfers {
 		executive.process_transfer(transfer.clone())?;
 	}
+
+	Ok(())
+}
+
+/// Given a block, execute based on a parent state.
+pub fn execute_block<C: Config>(block: &BeaconBlock, state: &mut BeaconState, config: &C) -> Result<(), Error> {
+	execute_block_no_verify_state_root(block, state, config)?;
+
+	let mut executive = Executive {
+		state, config
+	};
 
 	executive.verify_block_state_root(block)?;
 

--- a/beacon/src/executive/transition/per_block/operations/proposer_slashing.rs
+++ b/beacon/src/executive/transition/per_block/operations/proposer_slashing.rs
@@ -36,6 +36,10 @@ impl<'state, 'config, C: Config> Executive<'state, 'config, C> {
 		}
 
 		{
+			if proposer_slashing.proposer_index as usize >= self.state.validator_registry.len() {
+				return Err(Error::ProposerSlashingInvalidProposerIndex)
+			}
+
 			let proposer = &self.state.validator_registry[
 				proposer_slashing.proposer_index as usize
 			];

--- a/beacon/src/executive/transition/per_block/operations/transfer.rs
+++ b/beacon/src/executive/transition/per_block/operations/transfer.rs
@@ -39,7 +39,7 @@ impl<'state, 'config, C: Config> Executive<'state, 'config, C> {
 			 .activation_eligibility_epoch == self.config.far_future_epoch() ||
 			 self.current_epoch() >=
 			 self.state.validator_registry[transfer.sender as usize].withdrawable_epoch ||
-			 transfer.amount + transfer.fee + self.config.max_effective_balance() <
+			 transfer.amount + transfer.fee + self.config.max_effective_balance() <=
 			 self.state.balances[transfer.sender as usize])
 		{
 			return Err(Error::TransferNoFund)

--- a/yamltests/Cargo.toml
+++ b/yamltests/Cargo.toml
@@ -11,3 +11,4 @@ serde_yaml = "0.8"
 clap = "2.32"
 ssz = { path = "../utils/ssz" }
 beacon = { path = "../beacon" }
+crypto = { package = "shasper-crypto", path = "../crypto" }

--- a/yamltests/scripts/run.sh
+++ b/yamltests/scripts/run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+scripts/run_minimal.sh
+scripts/run_mainnet.sh

--- a/yamltests/scripts/run.sh
+++ b/yamltests/scripts/run.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 scripts/run_minimal.sh
 scripts/run_mainnet.sh

--- a/yamltests/scripts/run_mainnet.sh
+++ b/yamltests/scripts/run_mainnet.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+cargo run --release -- -r attestation res/spectests/tests/operations/attestation/attestation_mainnet.yaml
+cargo run --release -- -r attester_slashing res/spectests/tests/operations/attester_slashing/attester_slashing_mainnet.yaml
+cargo run --release -- -r block_header res/spectests/tests/operations/block_header/block_header_mainnet.yaml
+cargo run --release -- -r deposit res/spectests/tests/operations/deposit/deposit_mainnet.yaml
+cargo run --release -- -r proposer_slashing res/spectests/tests/operations/proposer_slashing/proposer_slashing_mainnet.yaml
+cargo run --release -- -r transfer res/spectests/tests/operations/transfer/transfer_mainnet.yaml
+
+cargo run --release -- -r crosslinks res/spectests/tests/epoch_processing/crosslinks/crosslinks_mainnet.yaml
+cargo run --release -- -r registry_updates res/spectests/tests/epoch_processing/registry_updates/registry_updates_mainnet.yaml
+
+cargo run --release -- -r blocks res/spectests/tests/sanity/blocks/blocksanity_s_mainnet.yaml
+cargo run --release -- -r slots res/spectests/tests/sanity/slots/slotsanity_s_mainnet.yaml

--- a/yamltests/scripts/run_mainnet.sh
+++ b/yamltests/scripts/run_mainnet.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 
-cargo run --release -- -r attestation res/spectests/tests/operations/attestation/attestation_mainnet.yaml
-cargo run --release -- -r attester_slashing res/spectests/tests/operations/attester_slashing/attester_slashing_mainnet.yaml
-cargo run --release -- -r block_header res/spectests/tests/operations/block_header/block_header_mainnet.yaml
-cargo run --release -- -r deposit res/spectests/tests/operations/deposit/deposit_mainnet.yaml
-cargo run --release -- -r proposer_slashing res/spectests/tests/operations/proposer_slashing/proposer_slashing_mainnet.yaml
-cargo run --release -- -r transfer res/spectests/tests/operations/transfer/transfer_mainnet.yaml
+set -euo pipefail
 
-cargo run --release -- -r crosslinks res/spectests/tests/epoch_processing/crosslinks/crosslinks_mainnet.yaml
-cargo run --release -- -r registry_updates res/spectests/tests/epoch_processing/registry_updates/registry_updates_mainnet.yaml
+cargo run --release -- --config full -r attestation res/spectests/tests/operations/attestation/attestation_mainnet.yaml
+cargo run --release -- --config full -r attester_slashing res/spectests/tests/operations/attester_slashing/attester_slashing_mainnet.yaml
+cargo run --release -- --config full -r block_header res/spectests/tests/operations/block_header/block_header_mainnet.yaml
+cargo run --release -- --config full -r deposit res/spectests/tests/operations/deposit/deposit_mainnet.yaml
+cargo run --release -- --config full -r proposer_slashing res/spectests/tests/operations/proposer_slashing/proposer_slashing_mainnet.yaml
+cargo run --release -- --config full -r transfer res/spectests/tests/operations/transfer/transfer_mainnet.yaml
 
-cargo run --release -- -r blocks res/spectests/tests/sanity/blocks/blocksanity_s_mainnet.yaml
-cargo run --release -- -r slots res/spectests/tests/sanity/slots/slotsanity_s_mainnet.yaml
+cargo run --release -- --config full -r crosslinks res/spectests/tests/epoch_processing/crosslinks/crosslinks_mainnet.yaml
+cargo run --release -- --config full -r registry_updates res/spectests/tests/epoch_processing/registry_updates/registry_updates_mainnet.yaml
+
+cargo run --release -- --config full -r blocks res/spectests/tests/sanity/blocks/blocksanity_s_mainnet.yaml
+cargo run --release -- --config full -r slots res/spectests/tests/sanity/slots/slotsanity_s_mainnet.yaml

--- a/yamltests/scripts/run_minimal.sh
+++ b/yamltests/scripts/run_minimal.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 cargo run --release -- -r attestation res/spectests/tests/operations/attestation/attestation_minimal.yaml
 cargo run --release -- -r attester_slashing res/spectests/tests/operations/attester_slashing/attester_slashing_minimal.yaml
 cargo run --release -- -r block_header res/spectests/tests/operations/block_header/block_header_minimal.yaml

--- a/yamltests/scripts/run_minimal.sh
+++ b/yamltests/scripts/run_minimal.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+cargo run --release -- -r attestation res/spectests/tests/operations/attestation/attestation_minimal.yaml
+cargo run --release -- -r attester_slashing res/spectests/tests/operations/attester_slashing/attester_slashing_minimal.yaml
+cargo run --release -- -r block_header res/spectests/tests/operations/block_header/block_header_minimal.yaml
+cargo run --release -- -r deposit res/spectests/tests/operations/deposit/deposit_minimal.yaml
+cargo run --release -- -r proposer_slashing res/spectests/tests/operations/proposer_slashing/proposer_slashing_minimal.yaml
+cargo run --release -- -r transfer res/spectests/tests/operations/transfer/transfer_minimal.yaml
+
+cargo run --release -- -r crosslinks res/spectests/tests/epoch_processing/crosslinks/crosslinks_minimal.yaml
+cargo run --release -- -r registry_updates res/spectests/tests/epoch_processing/registry_updates/registry_updates_minimal.yaml
+
+cargo run --release -- -r blocks res/spectests/tests/sanity/blocks/blocksanity_s_minimal.yaml
+cargo run --release -- -r slots res/spectests/tests/sanity/slots/slotsanity_s_minimal.yaml

--- a/yamltests/src/epoch_processing.rs
+++ b/yamltests/src/epoch_processing.rs
@@ -1,0 +1,20 @@
+use serde_derive::{Serialize, Deserialize};
+use beacon::types::BeaconState;
+use beacon::Config;
+use crate::{Test, run_test_with};
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct CrosslinksTest {
+	pub description: String,
+	pub pre: BeaconState,
+	pub post: Option<BeaconState>,
+}
+
+impl Test for CrosslinksTest {
+	fn run<C: Config>(&self, config: &C) {
+		run_test_with(&self.description, &self.pre, self.post.as_ref(), config, |executive| {
+			executive.process_crosslinks()
+		});
+	}
+}

--- a/yamltests/src/epoch_processing.rs
+++ b/yamltests/src/epoch_processing.rs
@@ -18,3 +18,19 @@ impl Test for CrosslinksTest {
 		});
 	}
 }
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct RegistryUpdatesTest {
+	pub description: String,
+	pub pre: BeaconState,
+	pub post: Option<BeaconState>,
+}
+
+impl Test for RegistryUpdatesTest {
+	fn run<C: Config>(&self, config: &C) {
+		run_test_with(&self.description, &self.pre, self.post.as_ref(), config, |executive| {
+			executive.process_registry_updates()
+		});
+	}
+}

--- a/yamltests/src/lib.rs
+++ b/yamltests/src/lib.rs
@@ -2,7 +2,7 @@ mod epoch_processing;
 mod operations;
 
 pub use epoch_processing::{CrosslinksTest, RegistryUpdatesTest};
-pub use operations::{AttestationTest, AttesterSlashingTest, BlockHeaderTest, DepositTest, ProposerSlashingTest};
+pub use operations::{AttestationTest, AttesterSlashingTest, BlockHeaderTest, DepositTest, ProposerSlashingTest, TransferTest};
 
 use serde_derive::{Serialize, Deserialize};
 use beacon::types::BeaconState;

--- a/yamltests/src/lib.rs
+++ b/yamltests/src/lib.rs
@@ -1,6 +1,6 @@
 mod epoch_processing;
 
-pub use epoch_processing::CrosslinksTest;
+pub use epoch_processing::{CrosslinksTest, RegistryUpdatesTest};
 
 use serde_derive::{Serialize, Deserialize};
 use beacon::types::{BeaconState, Deposit};

--- a/yamltests/src/lib.rs
+++ b/yamltests/src/lib.rs
@@ -1,9 +1,11 @@
 mod epoch_processing;
+mod operations;
 
 pub use epoch_processing::{CrosslinksTest, RegistryUpdatesTest};
+pub use operations::{DepositTest};
 
 use serde_derive::{Serialize, Deserialize};
-use beacon::types::{BeaconState, Deposit};
+use beacon::types::BeaconState;
 use beacon::{Executive, Config, Error};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -19,25 +21,8 @@ pub struct Collection<T> {
 	pub test_cases: Vec<T>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(deny_unknown_fields)]
-pub struct DepositTest {
-	pub description: String,
-	pub pre: BeaconState,
-	pub deposit: Deposit,
-	pub post: Option<BeaconState>,
-}
-
 pub trait Test {
 	fn run<C: Config>(&self, config: &C);
-}
-
-impl Test for DepositTest {
-	fn run<C: Config>(&self, config: &C) {
-		run_test_with(&self.description, &self.pre, self.post.as_ref(), config, |executive| {
-			executive.process_deposit(self.deposit.clone())
-		});
-	}
 }
 
 pub fn run_test_with<C: Config, F: FnOnce(&mut Executive<C>) -> Result<(), Error>>(

--- a/yamltests/src/lib.rs
+++ b/yamltests/src/lib.rs
@@ -2,7 +2,7 @@ mod epoch_processing;
 mod operations;
 
 pub use epoch_processing::{CrosslinksTest, RegistryUpdatesTest};
-pub use operations::{AttestationTest, AttesterSlashingTest, DepositTest};
+pub use operations::{AttestationTest, AttesterSlashingTest, BlockHeaderTest, DepositTest};
 
 use serde_derive::{Serialize, Deserialize};
 use beacon::types::BeaconState;

--- a/yamltests/src/lib.rs
+++ b/yamltests/src/lib.rs
@@ -2,7 +2,7 @@ mod epoch_processing;
 mod operations;
 
 pub use epoch_processing::{CrosslinksTest, RegistryUpdatesTest};
-pub use operations::{AttestationTest, DepositTest};
+pub use operations::{AttestationTest, AttesterSlashingTest, DepositTest};
 
 use serde_derive::{Serialize, Deserialize};
 use beacon::types::BeaconState;

--- a/yamltests/src/lib.rs
+++ b/yamltests/src/lib.rs
@@ -101,7 +101,7 @@ mod tests {
 	#[test]
 	fn deposit_small() {
 		let config = NoVerificationConfig::small();
-		let coll = serde_yaml::from_str(&include_str!("../res/spectests/tests/operations/deposits/deposit_minimal.yaml")).unwrap();
+		let coll = serde_yaml::from_str(&include_str!("../res/spectests/tests/operations/deposit/deposit_minimal.yaml")).unwrap();
 		run_collection::<DepositTest, _>(coll, &config);
 	}
 }

--- a/yamltests/src/lib.rs
+++ b/yamltests/src/lib.rs
@@ -2,7 +2,7 @@ mod epoch_processing;
 mod operations;
 
 pub use epoch_processing::{CrosslinksTest, RegistryUpdatesTest};
-pub use operations::{AttestationTest, AttesterSlashingTest, BlockHeaderTest, DepositTest};
+pub use operations::{AttestationTest, AttesterSlashingTest, BlockHeaderTest, DepositTest, ProposerSlashingTest};
 
 use serde_derive::{Serialize, Deserialize};
 use beacon::types::BeaconState;

--- a/yamltests/src/main.rs
+++ b/yamltests/src/main.rs
@@ -38,6 +38,7 @@ fn main() {
 		"block_header" => run::<BlockHeaderTest, _>(file, &config),
 		"deposit" => run::<DepositTest, _>(file, &config),
 		"proposer_slashing" => run::<ProposerSlashingTest, _>(file, &config),
+		"transfer" => run::<TransferTest, _>(file, &config),
 		"crosslinks" => run::<CrosslinksTest, _>(file, &config),
 		"registry_updates" => run::<RegistryUpdatesTest, _>(file, &config),
 		_ => panic!("Unsupported runner"),

--- a/yamltests/src/main.rs
+++ b/yamltests/src/main.rs
@@ -2,8 +2,9 @@ use std::fs::File;
 use std::io::BufReader;
 
 use clap::{App, Arg};
-use beacon::NoVerificationConfig;
-use yamltests::{Collection, DepositTest, run_collection};
+use beacon::{Config, NoVerificationConfig};
+use serde::de::DeserializeOwned;
+use yamltests::{Test, Collection, DepositTest, CrosslinksTest, run_collection};
 
 fn main() {
 	let matches = App::new("yamltests")
@@ -13,19 +14,34 @@ fn main() {
         .arg(Arg::with_name("FILE")
              .help("Target yaml file to import")
              .required(true))
-		.arg(Arg::with_name("config")
+		.arg(Arg::with_name("RUNNER")
+			 .help("Runner of the test")
+			 .long("runner")
+			 .short("r")
+			 .takes_value(true)
+			 .required(true))
+		.arg(Arg::with_name("CONFIG")
 			 .help("Run tests with the given config")
 			 .long("config")
 			 .takes_value(true))
         .get_matches();
 
 	let file = File::open(matches.value_of("FILE").expect("FILE parameter not found")).expect("Open file failed");
-	let coll = serde_yaml::from_reader::<_, Collection<DepositTest>>(BufReader::new(file)).expect("Parse test cases failed");
-	let config = match matches.value_of("config") {
+	let config = match matches.value_of("CONFIG") {
 		Some("small") | None => NoVerificationConfig::small(),
 		Some("full") => NoVerificationConfig::full(),
 		_ => panic!("Unknown config"),
 	};
+	match matches.value_of("RUNNER").expect("RUN parameter not found") {
+		"deposit" => run::<DepositTest, _>(file, &config),
+		"crosslinks" => run::<CrosslinksTest, _>(file, &config),
+		_ => panic!("Unsupported runner"),
+	}
+}
 
-	run_collection(coll, &config);
+fn run<T: Test + DeserializeOwned, C: Config>(file: File, config: &C) {
+	let reader = BufReader::new(file);
+	let coll = serde_yaml::from_reader::<_, Collection<T>>(reader).expect("Parse test cases failed");
+
+	run_collection(coll, config);
 }

--- a/yamltests/src/main.rs
+++ b/yamltests/src/main.rs
@@ -34,6 +34,7 @@ fn main() {
 	};
 	match matches.value_of("RUNNER").expect("RUN parameter not found") {
 		"attestation" => run::<AttestationTest, _>(file, &config),
+		"attester_slashing" => run::<AttesterSlashingTest, _>(file, &config),
 		"deposit" => run::<DepositTest, _>(file, &config),
 		"crosslinks" => run::<CrosslinksTest, _>(file, &config),
 		"registry_updates" => run::<RegistryUpdatesTest, _>(file, &config),

--- a/yamltests/src/main.rs
+++ b/yamltests/src/main.rs
@@ -27,7 +27,7 @@ fn main() {
         .get_matches();
 
 	let file = File::open(matches.value_of("FILE").expect("FILE parameter not found")).expect("Open file failed");
-	let config = match matches.value_of("CONFIG") {
+	let mut config = match matches.value_of("CONFIG") {
 		Some("small") | None => NoVerificationConfig::small(),
 		Some("full") => NoVerificationConfig::full(),
 		_ => panic!("Unknown config"),
@@ -41,6 +41,11 @@ fn main() {
 		"transfer" => run::<TransferTest, _>(file, &config),
 		"crosslinks" => run::<CrosslinksTest, _>(file, &config),
 		"registry_updates" => run::<RegistryUpdatesTest, _>(file, &config),
+		"blocks" => {
+			config.max_transfers = 1; // Work-around a bug in test https://github.com/ethereum/eth2.0-specs/issues/1147
+			run::<BlocksTest, _>(file, &config);
+		},
+		"slots" => run::<SlotsTest, _>(file, &config),
 		_ => panic!("Unsupported runner"),
 	}
 }

--- a/yamltests/src/main.rs
+++ b/yamltests/src/main.rs
@@ -37,6 +37,7 @@ fn main() {
 		"attester_slashing" => run::<AttesterSlashingTest, _>(file, &config),
 		"block_header" => run::<BlockHeaderTest, _>(file, &config),
 		"deposit" => run::<DepositTest, _>(file, &config),
+		"proposer_slashing" => run::<ProposerSlashingTest, _>(file, &config),
 		"crosslinks" => run::<CrosslinksTest, _>(file, &config),
 		"registry_updates" => run::<RegistryUpdatesTest, _>(file, &config),
 		_ => panic!("Unsupported runner"),

--- a/yamltests/src/main.rs
+++ b/yamltests/src/main.rs
@@ -4,7 +4,7 @@ use std::io::BufReader;
 use clap::{App, Arg};
 use beacon::{Config, NoVerificationConfig};
 use serde::de::DeserializeOwned;
-use yamltests::{Test, Collection, DepositTest, CrosslinksTest, run_collection};
+use yamltests::*;
 
 fn main() {
 	let matches = App::new("yamltests")
@@ -35,6 +35,7 @@ fn main() {
 	match matches.value_of("RUNNER").expect("RUN parameter not found") {
 		"deposit" => run::<DepositTest, _>(file, &config),
 		"crosslinks" => run::<CrosslinksTest, _>(file, &config),
+		"registry_updates" => run::<RegistryUpdatesTest, _>(file, &config),
 		_ => panic!("Unsupported runner"),
 	}
 }

--- a/yamltests/src/main.rs
+++ b/yamltests/src/main.rs
@@ -35,6 +35,7 @@ fn main() {
 	match matches.value_of("RUNNER").expect("RUN parameter not found") {
 		"attestation" => run::<AttestationTest, _>(file, &config),
 		"attester_slashing" => run::<AttesterSlashingTest, _>(file, &config),
+		"block_header" => run::<BlockHeaderTest, _>(file, &config),
 		"deposit" => run::<DepositTest, _>(file, &config),
 		"crosslinks" => run::<CrosslinksTest, _>(file, &config),
 		"registry_updates" => run::<RegistryUpdatesTest, _>(file, &config),

--- a/yamltests/src/main.rs
+++ b/yamltests/src/main.rs
@@ -33,6 +33,7 @@ fn main() {
 		_ => panic!("Unknown config"),
 	};
 	match matches.value_of("RUNNER").expect("RUN parameter not found") {
+		"attestation" => run::<AttestationTest, _>(file, &config),
 		"deposit" => run::<DepositTest, _>(file, &config),
 		"crosslinks" => run::<CrosslinksTest, _>(file, &config),
 		"registry_updates" => run::<RegistryUpdatesTest, _>(file, &config),

--- a/yamltests/src/operations.rs
+++ b/yamltests/src/operations.rs
@@ -1,5 +1,5 @@
 use serde_derive::{Serialize, Deserialize};
-use beacon::types::{BeaconState, Deposit, Attestation};
+use beacon::types::{BeaconState, Deposit, Attestation, AttesterSlashing};
 use beacon::Config;
 use crate::{TestWithBLS, run_test_with};
 
@@ -19,6 +19,26 @@ impl TestWithBLS for AttestationTest {
 	fn run<C: Config>(&self, config: &C) {
 		run_test_with(&self.description, &self.pre, self.post.as_ref(), config, |executive| {
 			executive.process_attestation(self.attestation.clone())
+		});
+	}
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct AttesterSlashingTest {
+	pub bls_setting: Option<usize>,
+	pub description: String,
+	pub pre: BeaconState,
+	pub attester_slashing: AttesterSlashing,
+	pub post: Option<BeaconState>,
+}
+
+impl TestWithBLS for AttesterSlashingTest {
+	fn bls_setting(&self) -> Option<usize> { self.bls_setting }
+
+	fn run<C: Config>(&self, config: &C) {
+		run_test_with(&self.description, &self.pre, self.post.as_ref(), config, |executive| {
+			executive.process_attester_slashing(self.attester_slashing.clone())
 		});
 	}
 }

--- a/yamltests/src/operations.rs
+++ b/yamltests/src/operations.rs
@@ -1,5 +1,5 @@
 use serde_derive::{Serialize, Deserialize};
-use beacon::types::{BeaconState, Deposit, Attestation, AttesterSlashing, ProposerSlashing, BeaconBlock};
+use beacon::types::{BeaconState, Deposit, Attestation, AttesterSlashing, ProposerSlashing, Transfer, BeaconBlock};
 use beacon::Config;
 use crate::{TestWithBLS, run_test_with};
 
@@ -99,6 +99,26 @@ impl TestWithBLS for ProposerSlashingTest {
 	fn run<C: Config>(&self, config: &C) {
 		run_test_with(&self.description, &self.pre, self.post.as_ref(), config, |executive| {
 			executive.process_proposer_slashing(self.proposer_slashing.clone())
+		});
+	}
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct TransferTest {
+	pub bls_setting: Option<usize>,
+	pub description: String,
+	pub pre: BeaconState,
+	pub transfer: Transfer,
+	pub post: Option<BeaconState>,
+}
+
+impl TestWithBLS for TransferTest {
+	fn bls_setting(&self) -> Option<usize> { self.bls_setting }
+
+	fn run<C: Config>(&self, config: &C) {
+		run_test_with(&self.description, &self.pre, self.post.as_ref(), config, |executive| {
+			executive.process_transfer(self.transfer.clone())
 		});
 	}
 }

--- a/yamltests/src/operations.rs
+++ b/yamltests/src/operations.rs
@@ -1,5 +1,5 @@
 use serde_derive::{Serialize, Deserialize};
-use beacon::types::{BeaconState, Deposit, Attestation, AttesterSlashing, BeaconBlock};
+use beacon::types::{BeaconState, Deposit, Attestation, AttesterSlashing, ProposerSlashing, BeaconBlock};
 use beacon::Config;
 use crate::{TestWithBLS, run_test_with};
 
@@ -79,6 +79,26 @@ impl TestWithBLS for DepositTest {
 	fn run<C: Config>(&self, config: &C) {
 		run_test_with(&self.description, &self.pre, self.post.as_ref(), config, |executive| {
 			executive.process_deposit(self.deposit.clone())
+		});
+	}
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct ProposerSlashingTest {
+	pub bls_setting: Option<usize>,
+	pub description: String,
+	pub pre: BeaconState,
+	pub proposer_slashing: ProposerSlashing,
+	pub post: Option<BeaconState>,
+}
+
+impl TestWithBLS for ProposerSlashingTest {
+	fn bls_setting(&self) -> Option<usize> { self.bls_setting }
+
+	fn run<C: Config>(&self, config: &C) {
+		run_test_with(&self.description, &self.pre, self.post.as_ref(), config, |executive| {
+			executive.process_proposer_slashing(self.proposer_slashing.clone())
 		});
 	}
 }

--- a/yamltests/src/operations.rs
+++ b/yamltests/src/operations.rs
@@ -1,5 +1,5 @@
 use serde_derive::{Serialize, Deserialize};
-use beacon::types::{BeaconState, Deposit, Attestation, AttesterSlashing};
+use beacon::types::{BeaconState, Deposit, Attestation, AttesterSlashing, BeaconBlock};
 use beacon::Config;
 use crate::{TestWithBLS, run_test_with};
 
@@ -39,6 +39,26 @@ impl TestWithBLS for AttesterSlashingTest {
 	fn run<C: Config>(&self, config: &C) {
 		run_test_with(&self.description, &self.pre, self.post.as_ref(), config, |executive| {
 			executive.process_attester_slashing(self.attester_slashing.clone())
+		});
+	}
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct BlockHeaderTest {
+	pub bls_setting: Option<usize>,
+	pub description: String,
+	pub pre: BeaconState,
+	pub block: BeaconBlock,
+	pub post: Option<BeaconState>,
+}
+
+impl TestWithBLS for BlockHeaderTest {
+	fn bls_setting(&self) -> Option<usize> { self.bls_setting }
+
+	fn run<C: Config>(&self, config: &C) {
+		run_test_with(&self.description, &self.pre, self.post.as_ref(), config, |executive| {
+			executive.process_block_header(&self.block)
 		});
 	}
 }

--- a/yamltests/src/operations.rs
+++ b/yamltests/src/operations.rs
@@ -1,0 +1,35 @@
+use serde_derive::{Serialize, Deserialize};
+use beacon::types::{BeaconState, Deposit};
+use beacon::{Config, ParameteredConfig, FromConfig};
+use crypto::bls;
+use crate::{Test, run_test_with};
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct DepositTest {
+	pub bls_setting: Option<usize>,
+	pub description: String,
+	pub pre: BeaconState,
+	pub deposit: Deposit,
+	pub post: Option<BeaconState>,
+}
+
+impl Test for DepositTest {
+	fn run<C: Config>(&self, config: &C) {
+		let bls_setting = self.bls_setting.unwrap_or(0);
+		match bls_setting {
+			0 | 2 => {
+				run_test_with(&self.description, &self.pre, self.post.as_ref(), config, |executive| {
+					executive.process_deposit(self.deposit.clone())
+				});
+			},
+			1 => {
+				let config = ParameteredConfig::<bls::Verification>::from_config(config);
+				run_test_with(&self.description, &self.pre, self.post.as_ref(), &config, |executive| {
+					executive.process_deposit(self.deposit.clone())
+				});
+			},
+			_ => panic!("Invalid test format"),
+		}
+	}
+}

--- a/yamltests/src/sanity.rs
+++ b/yamltests/src/sanity.rs
@@ -1,0 +1,50 @@
+use serde_derive::{Serialize, Deserialize};
+use beacon::types::{BeaconState, BeaconBlock};
+use beacon::{self, Config};
+use crate::{TestWithBLS, run_state_test_with};
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct BlocksTest {
+	pub bls_setting: Option<usize>,
+	pub description: String,
+	pub pre: BeaconState,
+	pub blocks: Vec<BeaconBlock>,
+	pub post: Option<BeaconState>,
+}
+
+impl TestWithBLS for BlocksTest {
+	fn bls_setting(&self) -> Option<usize> { self.bls_setting }
+
+	fn run<C: Config>(&self, config: &C) {
+		run_state_test_with(&self.description, &self.pre, self.post.as_ref(), |state| {
+			for block in self.blocks.clone() {
+				beacon::execute_block_no_verify_state_root(&block, state, config)?
+			}
+
+			Ok(())
+		});
+	}
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct SlotsTest {
+	pub bls_setting: Option<usize>,
+	pub description: String,
+	pub pre: BeaconState,
+	pub slots: u64,
+	pub post: Option<BeaconState>,
+}
+
+impl TestWithBLS for SlotsTest {
+	fn bls_setting(&self) -> Option<usize> { self.bls_setting }
+
+	fn run<C: Config>(&self, config: &C) {
+		run_state_test_with(&self.description, &self.pre, self.post.as_ref(), |state| {
+			let target_slot = state.slot + self.slots;
+
+			beacon::initialize_block(state, target_slot, config)
+		});
+	}
+}


### PR DESCRIPTION
This adds all operations, sanity, epoch processing tests for spec v0.6.3. You can run it with

```
cd yamltests
scripts/run.sh
```

Two workarounds are needed, and they're reported in upstream issues https://github.com/ethereum/eth2.0-specs/issues/1147 https://github.com/ethereum/eth2.0-specs/issues/1146