### PR TITLE
Handle attestation duplicated aggregation

### DIFF
--- a/blockchain/src/pool.rs
+++ b/blockchain/src/pool.rs
@@ -5,7 +5,7 @@ use ssz::Digestible;
 use std::collections::HashMap;
 
 pub struct AttestationPool<'config, C: Config> {
-	pool: HashMap<H256, Attestation>,
+	pool: HashMap<H256, Vec<Attestation>>,
 	_config: &'config C,
 }
 
@@ -24,23 +24,43 @@ impl<'config, C: Config> AttestationPool<'config, C> {
 		}).as_slice());
 
 		self.pool.entry(hash)
-			.and_modify(|existing| {
-				// TODO: Handle cases for duplicate signatures.
-				for i in 0..(existing.aggregation_bitfield.0.len() * 8) {
-					if attestation.aggregation_bitfield.get_bit(i) {
-						assert_eq!(existing.aggregation_bitfield.get_bit(i), false);
+			.and_modify(|existings| {
+				let attestation = attestation.clone();
+				let mut aggregated = false;
+
+				for existing in existings.iter_mut() {
+					let has_duplicate = {
+						let mut has_duplicate = false;
+						for i in 0..(existing.aggregation_bitfield.0.len() * 8) {
+							if attestation.aggregation_bitfield.get_bit(i) {
+								has_duplicate = true;
+							}
+						}
+						has_duplicate
+					};
+
+					if has_duplicate {
+						continue
 					}
+
+					existing.aggregation_bitfield |= attestation.aggregation_bitfield.clone();
+					for i in 0..attestation.custody_bitfield.0.len() {
+						assert_eq!(attestation.custody_bitfield.0[i], 0);
+					}
+					existing.custody_bitfield |= attestation.custody_bitfield.clone();
+					existing.signature = C::aggregate_signatures(&[
+						existing.signature, attestation.signature.clone()
+					]);
+
+					aggregated = true;
+					break;
 				}
-				existing.aggregation_bitfield |= attestation.aggregation_bitfield.clone();
-				for i in 0..attestation.custody_bitfield.0.len() {
-					assert_eq!(attestation.custody_bitfield.0[i], 0);
+
+				if !aggregated {
+					existings.push(attestation);
 				}
-				existing.custody_bitfield |= attestation.custody_bitfield.clone();
-				existing.signature = C::aggregate_signatures(&[
-					existing.signature, attestation.signature.clone()
-				]);
 			})
-			.or_insert(attestation);
+			.or_insert(vec![attestation]);
     }
 
 	pub fn pop(&mut self, key: &H256) {
@@ -48,6 +68,6 @@ impl<'config, C: Config> AttestationPool<'config, C> {
 	}
 
 	pub fn iter(&self) -> impl Iterator<Item=(&H256, &Attestation)> {
-		self.pool.iter()
+		self.pool.iter().flat_map(|(h, ats)| ats.iter().map(move |at| (h, at)))
 	}
 }


### PR DESCRIPTION
Fixes #148.

When there're duplicated attestation bitfields, try to find an attestation that does not have duplication and merge with it. If that's not possible, add it as a new attestation.