### PR TITLE
Update test vectors to v0.7.1 and integrate CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ test-rust-stable:
   script:
     - ./scripts/init.sh
     - ./scripts/build.sh
+    - cd yamltests && ./scripts/run.sh
     - time cargo test --all --release --locked
     - sccache -s
   only:

--- a/beacon/src/executive/mod.rs
+++ b/beacon/src/executive/mod.rs
@@ -43,10 +43,6 @@ pub struct Executive<'state, 'config, C: Config> {
 pub enum Strategy {
 	/// The normal execution strategy
 	Full,
-	/// Execution without verifying the state root
-	IgnoreStateRoot,
-	/// Execution without verifying the state root, and without randao
-	IgnoreRandaoAndStateRoot,
 }
 
 /// Given a block, execute based on a parent state.

--- a/beacon/src/executive/transition/mod.rs
+++ b/beacon/src/executive/transition/mod.rs
@@ -30,11 +30,10 @@ impl<'state, 'config, C: Config> Executive<'state, 'config, C> {
 		strategy: Strategy,
 	) -> Result<(), Error> {
 		self.process_slots(block.slot())?;
-		self.process_block(block, strategy)?;
+		self.process_block(block)?;
 
 		match strategy {
-			Strategy::IgnoreStateRoot | Strategy::IgnoreRandaoAndStateRoot => (),
-			_ => {
+			Strategy::Full => {
 				if !(block.state_root() == &H256::from_slice(
 					Digestible::<C::Digest>::hash(self.state).as_slice()
 				)) {

--- a/beacon/src/executive/transition/per_block/mod.rs
+++ b/beacon/src/executive/transition/per_block/mod.rs
@@ -20,7 +20,7 @@ mod eth1;
 mod operations;
 
 use ssz::Digestible;
-use crate::{Config, Error, Executive, Strategy};
+use crate::{Config, Error, Executive};
 use crate::types::Block;
 
 impl<'state, 'config, C: Config> Executive<'state, 'config, C> {
@@ -28,13 +28,9 @@ impl<'state, 'config, C: Config> Executive<'state, 'config, C> {
 	pub fn process_block<B: Block + Digestible<C::Digest>>(
 		&mut self,
 		block: &B,
-		strategy: Strategy,
 	) -> Result<(), Error> {
 		self.process_block_header(block)?;
-		match strategy {
-			Strategy::IgnoreRandaoAndStateRoot => (),
-			_ => self.process_randao(block.body())?,
-		}
+		self.process_randao(block.body())?;
 		self.process_eth1_data(block.body());
 		self.process_operations(block.body())?;
 

--- a/yamltests/src/main.rs
+++ b/yamltests/src/main.rs
@@ -42,10 +42,7 @@ fn main() {
 		"voluntary_exit" => run::<VoluntaryExitTest, _>(file, &config),
 		"crosslinks" => run::<CrosslinksTest, _>(file, &config),
 		"registry_updates" => run::<RegistryUpdatesTest, _>(file, &config),
-		"blocks" => {
-			config.max_transfers = 1; // Work-around a bug in test https://github.com/ethereum/eth2.0-specs/issues/1147
-			run::<BlocksTest, _>(file, &config);
-		},
+		"blocks" => run::<BlocksTest, _>(file, &config),
 		"slots" => run::<SlotsTest, _>(file, &config),
 		_ => panic!("Unsupported runner"),
 	}

--- a/yamltests/src/main.rs
+++ b/yamltests/src/main.rs
@@ -27,7 +27,7 @@ fn main() {
         .get_matches();
 
 	let file = File::open(matches.value_of("FILE").expect("FILE parameter not found")).expect("Open file failed");
-	let mut config = match matches.value_of("CONFIG") {
+	let config = match matches.value_of("CONFIG") {
 		Some("small") | None => NoVerificationConfig::small(),
 		Some("full") => NoVerificationConfig::full(),
 		_ => panic!("Unknown config"),

--- a/yamltests/src/sanity.rs
+++ b/yamltests/src/sanity.rs
@@ -21,7 +21,7 @@ impl TestWithBLS for BlocksTest {
 			for block in self.blocks.clone() {
 				let mut executive = Executive { state, config };
 
-				executive.state_transition(&block, Strategy::IgnoreRandaoAndStateRoot)?
+				executive.state_transition(&block, Strategy::Full)?
 			}
 
 			Ok(())


### PR DESCRIPTION
- Update test vector to v0.7.1, removing workarounds https://github.com/ethereum/eth2.0-specs/issues/1169 https://github.com/ethereum/eth2.0-specs/issues/1147 https://github.com/ethereum/eth2.0-specs/issues/1146
- Integrate test suite to CI.