### PR TITLE
Reliable RocksDB error handling and `open_or_create`

### DIFF
--- a/blockchain/src/main.rs
+++ b/blockchain/src/main.rs
@@ -13,7 +13,6 @@ use shasper_blockchain::backend::ShasperBackend;
 use lmd_ghost::archive::{ArchiveGhostImporter, AncestorQuery};
 use clap::{App, Arg};
 use std::thread;
-use std::path::Path;
 use std::collections::HashMap;
 use core::time::Duration;
 use crypto::bls;
@@ -140,17 +139,9 @@ fn main() {
 	if let Some(path) = matches.value_of("data") {
 		println!("Using RocksDB backend");
 		let backend = ShasperBackend::new(
-			if Path::new(path).exists() {
-				RocksBackend::<_, (), State>::from_existing(
-					path
-				).unwrap()
-			} else {
-				RocksBackend::<_, (), State>::new_with_genesis(
-					path,
-					genesis_block.clone(),
-					genesis_state.into(),
-				).unwrap()
-			}
+			RocksBackend::<_, (), State>::open_or_create(path, || {
+				Ok((genesis_block.clone(), genesis_state.into()))
+			}).unwrap()
 		);
 		let lock = ImportLock::new();
 

--- a/blockchain/src/main.rs
+++ b/blockchain/src/main.rs
@@ -143,13 +143,13 @@ fn main() {
 			if Path::new(path).exists() {
 				RocksBackend::<_, (), State>::from_existing(
 					path
-				)
+				).unwrap()
 			} else {
 				RocksBackend::<_, (), State>::new_with_genesis(
 					path,
 					genesis_block.clone(),
 					genesis_state.into(),
-				)
+				).unwrap()
 			}
 		);
 		let lock = ImportLock::new();

--- a/blockchain/src/rocksdb.rs
+++ b/blockchain/src/rocksdb.rs
@@ -261,6 +261,22 @@ impl<'a, B: Block, A: Auxiliary<B>, S> ChainSettlement for RocksSettlement<'a, B
 	}
 }
 
+impl<'a, B: Block, A: Auxiliary<B>, S> RocksSettlement<'a, B, A, S> where
+	B::Identifier: Encode + Decode,
+	B: Encode + Decode,
+	A: Encode + Decode,
+	A::Key: Encode + Decode,
+	S: Encode + Decode,
+{
+	fn set_genesis(
+		&mut self,
+		genesis: B::Identifier
+	) {
+		let cf = self.backend.db.cf_handle(COLUMN_INFO).unwrap();
+		self.backend.db.put_cf_opt(cf, KEY_GENESIS.encode(), genesis.encode(), &WriteOptions::default()).unwrap();
+	}
+}
+
 impl<B: Block, A: Auxiliary<B>, S> ChainQuery for RocksBackend<B, A, S> where
 	B::Identifier: Encode + Decode,
 	B: Encode + Decode,
@@ -418,9 +434,7 @@ impl<B: Block, A: Auxiliary<B>, S> RocksBackend<B, A, S> where
 			true
 		);
 		settlement.insert_canon_depth_mapping(0, genesis_id);
-
-		let cf = settlement.backend.db.cf_handle(COLUMN_INFO).unwrap();
-		settlement.backend.db.put_cf_opt(cf, KEY_GENESIS.encode(), genesis_id.encode(), &WriteOptions::default()).unwrap();
+		settlement.set_genesis(genesis_id);
 		settlement.set_head(genesis_id);
 
 		db


### PR DESCRIPTION
- Make sure on the RocksDB backend layer, nothing will panic. Errors, if happened in the DB, will be propagated. The only possible panic should be just lock poisoning.
- Create a reliable `open_or_create` for RocksDB by checking keys `KEY_HEAD` and `KEY_GENESIS`.