### PR TITLE
Ensure docs and publish crate for ssz and beacon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "beacon"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bm-le 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -183,7 +183,7 @@ dependencies = [
  "primitive-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ssz 0.1.2",
+ "ssz 0.2.0",
  "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vecarray 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2258,7 +2258,7 @@ dependencies = [
 name = "shasper-blockchain"
 version = "0.1.0"
 dependencies = [
- "beacon 0.1.2",
+ "beacon 0.2.0",
  "blockchain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "blockchain-network-simple 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "blockchain-rocksdb 0.1.0",
@@ -2271,14 +2271,14 @@ dependencies = [
  "rocksdb 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "shasper-crypto 0.1.0",
- "ssz 0.1.2",
+ "ssz 0.2.0",
 ]
 
 [[package]]
 name = "shasper-crypto"
 version = "0.1.0"
 dependencies = [
- "beacon 0.1.2",
+ "beacon 0.2.0",
  "milagro_bls 0.9.0 (git+https://github.com/sigp/milagro_bls)",
 ]
 
@@ -2324,27 +2324,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ssz"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bm-le 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ssz-derive 0.1.2",
+ "ssz-derive 0.2.0",
  "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vecarray 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ssz-derive"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "deriving 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "ssz 0.1.2",
+ "ssz 0.2.0",
  "syn 0.15.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2353,7 +2353,7 @@ dependencies = [
 name = "ssztests"
 version = "0.1.0"
 dependencies = [
- "beacon 0.1.2",
+ "beacon 0.2.0",
  "bm-le 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2361,7 +2361,7 @@ dependencies = [
  "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "shasper-crypto 0.1.0",
- "ssz 0.1.2",
+ "ssz 0.2.0",
 ]
 
 [[package]]
@@ -2749,13 +2749,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "transitiontests"
 version = "0.1.0"
 dependencies = [
- "beacon 0.1.2",
+ "beacon 0.2.0",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "shasper-crypto 0.1.0",
- "ssz 0.1.2",
+ "ssz 0.2.0",
 ]
 
 [[package]]

--- a/beacon/Cargo.toml
+++ b/beacon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beacon"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Minimal Serenity beacon chain implementation"
 license = "GPL-3.0"
@@ -11,7 +11,7 @@ primitive-types = { version = "0.4", default-features = false }
 impl-serde = { version = "0.1", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 parity-codec = { version = "4.0", optional = true, features = ["derive"] }
-ssz = { version = "0.1", path = "../utils/ssz", default-features = false, features = ["derive"] }
+ssz = { version = "0.2", path = "../utils/ssz", default-features = false, features = ["derive"] }
 bm-le = { version = "0.8", default-features = false, features = ["derive"] }
 fixed-hash = { version = "0.3.0", default-features = false }
 sha2 = { version = "0.8", default-features = false }

--- a/beacon/src/config.rs
+++ b/beacon/src/config.rs
@@ -31,9 +31,9 @@ pub trait BLSConfig: Default + Clone + 'static {
 	fn verify_multiple(pubkeys: &[ValidatorId], messages: &[H256], signature: &Signature, domain: u64) -> bool;
 }
 
-/// Run bls without any verification.
 #[derive(Default, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Debug))]
+/// Run bls without any verification.
 pub struct BLSNoVerification;
 
 impl BLSConfig for BLSNoVerification {
@@ -55,21 +55,37 @@ impl BLSConfig for BLSNoVerification {
 pub trait Config: Default + Clone + PartialEq + Eq + core::fmt::Debug + 'static {
 	/// Digest hash function.
 	type Digest: Digest<OutputSize=typenum::U32>;
+	/// Max validators per committee.
 	type MaxValidatorsPerCommittee: Unsigned + core::fmt::Debug + Clone + Eq + PartialEq + Default;
+	/// Slots per historical root.
 	type SlotsPerHistoricalRoot: Unsigned + core::fmt::Debug + Clone + Eq + PartialEq + Default;
+	/// Maximum proposer slashings.
 	type MaxProposerSlashings: Unsigned + core::fmt::Debug + Clone + Eq + PartialEq + Default;
+	/// Maximum attester slashings.
 	type MaxAttesterSlashings: Unsigned + core::fmt::Debug + Clone + Eq + PartialEq + Default;
+	/// Maximum attestations in a given block.
 	type MaxAttestations: Unsigned + core::fmt::Debug + Clone + Eq + PartialEq + Default;
+	/// Maximum deposits in a given block.
 	type MaxDeposits: Unsigned + core::fmt::Debug + Clone + Eq + PartialEq + Default;
+	/// Maximum voluntary exists in a given block.
 	type MaxVoluntaryExits: Unsigned + core::fmt::Debug + Clone + Eq + PartialEq + Default;
+	/// Maximum transfers in a given block.
 	type MaxTransfers: Unsigned + core::fmt::Debug + Clone + Eq + PartialEq + Default;
+	/// Limit of historical roots.
 	type HistoricalRootsLimit: Unsigned + core::fmt::Debug + Clone + Eq + PartialEq + Default;
+	/// Shard count.
 	type ShardCount: Unsigned + core::fmt::Debug + Clone + Eq + PartialEq + Default;
+	/// Slots per epoch.
 	type SlotsPerEpoch: Unsigned + core::fmt::Debug + Clone + Eq + PartialEq + Default;
+	/// Slots per eth1 voting period.
 	type SlotsPerEth1VotingPeriod: Unsigned + core::fmt::Debug + Clone + Eq + PartialEq + Default;
+	/// Validator registry limit.
 	type ValidatorRegistryLimit: Unsigned + core::fmt::Debug + Clone + Eq + PartialEq + Default;
+	/// Epochs per historical vector.
 	type EpochsPerHistoricalVector: Unsigned + core::fmt::Debug + Clone + Eq + PartialEq + Default;
+	/// Epochs per slashings vector.
 	type EpochsPerSlashingsVector: Unsigned + core::fmt::Debug + Clone + Eq + PartialEq + Default;
+	/// Maximum attestations per epoch.
 	type MaxAttestationsPerEpoch: Unsigned + core::fmt::Debug + Clone + Eq + PartialEq + Default;
 
 	// === Misc ===
@@ -197,6 +213,7 @@ pub trait Config: Default + Clone + PartialEq + Eq + core::fmt::Debug + 'static 
 #[cfg_attr(feature = "std", derive(Debug))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "parity-codec", derive(parity_codec::Encode, parity_codec::Decode))]
+/// Minimal config.
 pub struct MinimalConfig;
 
 impl Config for MinimalConfig {
@@ -266,6 +283,7 @@ impl Config for MinimalConfig {
 #[cfg_attr(feature = "std", derive(Debug))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "parity-codec", derive(parity_codec::Encode, parity_codec::Decode))]
+/// Mainnet config.
 pub struct MainnetConfig;
 
 impl Config for MainnetConfig {

--- a/beacon/src/executive/helpers/mutators.rs
+++ b/beacon/src/executive/helpers/mutators.rs
@@ -3,15 +3,18 @@ use crate::{BeaconState, Config, Error, utils, consts};
 use core::cmp::max;
 
 impl<C: Config> BeaconState<C> {
+	/// Increase validator balance.
 	pub fn increase_balance(&mut self, index: ValidatorIndex, delta: Gwei) {
 		self.balances[index as usize] += delta;
 	}
 
+	/// Decrease validator balance.
 	pub fn decrease_balance(&mut self, index: ValidatorIndex, delta: Gwei) {
 		self.balances[index as usize] =
 			self.balances[index as usize].saturating_sub(delta);
 	}
 
+	/// Initiate validator exit.
 	pub fn initiate_validator_exit(&mut self, index: ValidatorIndex) {
 		if self.validators[index as usize].exit_epoch !=
 			consts::FAR_FUTURE_EPOCH
@@ -41,6 +44,7 @@ impl<C: Config> BeaconState<C> {
 			C::min_validator_withdrawability_delay();
 	}
 
+	/// Slash validator.
 	pub fn slash_validator(
 		&mut self,
 		slashed_index: ValidatorIndex,

--- a/beacon/src/executive/mod.rs
+++ b/beacon/src/executive/mod.rs
@@ -19,52 +19,78 @@ use crate::consts;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(deny_unknown_fields))]
 #[cfg_attr(feature = "parity-codec", derive(parity_codec::Encode, parity_codec::Decode))]
 #[cfg_attr(feature = "std", derive(Debug))]
+/// Beacon state.
 pub struct BeaconState<C: Config> {
 	// == Versioning ==
+	/// Genesis time as Unix timestamp.
 	pub genesis_time: Uint,
+	/// Current slot.
 	pub slot: Uint,
+	/// Fork version.
 	pub fork: Fork,
 
 	// == History ==
+	/// Latest blokc header.
 	pub latest_block_header: BeaconBlockHeader,
+	/// Past block roots.
 	pub block_roots: VecArray<H256, C::SlotsPerHistoricalRoot>,
+	/// Past state roots.
 	pub state_roots: VecArray<H256, C::SlotsPerHistoricalRoot>,
+	/// Past historical roots.
 	pub historical_roots: MaxVec<H256, C::HistoricalRootsLimit>,
 
 	// == Eth1 ==
+	/// Last accepted eth1 data.
 	pub eth1_data: Eth1Data,
+	/// Votes on eth1 data.
 	pub eth1_data_votes: MaxVec<Eth1Data, C::SlotsPerEth1VotingPeriod>,
+	/// Eth1 data deposit index.
 	pub eth1_deposit_index: Uint,
 
 	// == Registry ==
+	/// Validator registry.
 	pub validators: MaxVec<Validator, C::ValidatorRegistryLimit>,
 	#[bm(compact)]
+	/// Balance of the validators.
 	pub balances: MaxVec<Uint, C::ValidatorRegistryLimit>,
 
 	// == Shuffling ==
+	/// Start shard for shuffling.
 	pub start_shard: Uint,
+	/// Past randao mixes.
 	pub randao_mixes: VecArray<H256, C::EpochsPerHistoricalVector>,
+	/// Past active index roots.
 	pub active_index_roots: VecArray<H256, C::EpochsPerHistoricalVector>,
+	/// Past compact committees roots.
 	pub compact_committees_roots: VecArray<H256, C::EpochsPerHistoricalVector>,
 
 	// == Slashings ==
 	#[bm(compact)]
+	/// Past slashings.
 	pub slashings: VecArray<Uint, C::EpochsPerSlashingsVector>,
 
 	// == Attestations ==
+	/// Attestations on previous epoch.
 	pub previous_epoch_attestations: MaxVec<PendingAttestation<C>, C::MaxAttestationsPerEpoch>,
+	/// Attestations on current epoch.
 	pub current_epoch_attestations: MaxVec<PendingAttestation<C>, C::MaxAttestationsPerEpoch>,
 
 	// == Crosslinks ==
+	/// Previous crosslinks.
 	pub previous_crosslinks: VecArray<Crosslink, C::ShardCount>,
+	/// Current crosslinks.
 	pub current_crosslinks: VecArray<Crosslink, C::ShardCount>,
 
 	// == Finality ==
 	#[bm(compact)]
 	#[cfg_attr(feature = "serde", serde(serialize_with = "crate::utils::serialize_bitvector"))]
 	#[cfg_attr(feature = "serde", serde(deserialize_with = "crate::utils::deserialize_bitvector"))]
+	/// Justification bits for Casper.
 	pub justification_bits: VecArray<bool, consts::JustificationBitsLength>,
+	/// Previous justified checkpoint.
 	pub previous_justified_checkpoint: Checkpoint,
+	/// Current justified checkpoint.
 	pub current_justified_checkpoint: Checkpoint,
+	/// Last finalized checkpoint.
 	pub finalized_checkpoint: Checkpoint,
 }

--- a/beacon/src/executive/transition/per_block/header.rs
+++ b/beacon/src/executive/transition/per_block/header.rs
@@ -3,6 +3,7 @@ use crate::{Config, BeaconState, Error, BLSConfig};
 use bm_le::tree_root;
 
 impl<C: Config> BeaconState<C> {
+	/// Process a block header.
 	pub fn process_block_header<'a, 'b, B: Block, BLS: BLSConfig>(
 		&'a mut self,
 		block: &'b B

--- a/beacon/src/executive/transition/per_epoch/helpers.rs
+++ b/beacon/src/executive/transition/per_epoch/helpers.rs
@@ -5,6 +5,7 @@ use bm_le::tree_root;
 use core::cmp::Ordering;
 
 impl<C: Config> BeaconState<C> {
+	/// Get attestations with matching source at given epoch.
 	pub fn matching_source_attestations(
 		&self,
 		epoch: Epoch
@@ -18,6 +19,7 @@ impl<C: Config> BeaconState<C> {
 		}
 	}
 
+	/// Get attestations with matching target at given epoch.
 	pub fn matching_target_attestations(
 		&self,
 		epoch: Epoch
@@ -28,6 +30,7 @@ impl<C: Config> BeaconState<C> {
 		   .collect())
 	}
 
+	/// Get attestations with matching head at given epoch.
 	pub fn matching_head_attestations(
 		&self,
 		epoch: Epoch
@@ -47,6 +50,7 @@ impl<C: Config> BeaconState<C> {
 			})
 	}
 
+	/// Get indices of all unslashed validators within attestations.
 	pub fn unslashed_attesting_indices(
 		&self, attestations: &[PendingAttestation<C>]
 	) -> Result<Vec<ValidatorIndex>, Error> {
@@ -65,12 +69,14 @@ impl<C: Config> BeaconState<C> {
 		Ok(ret)
 	}
 
+	/// Get the total attesting balance given a list of attestations.
 	pub fn attesting_balance(
 		&self, attestations: &[PendingAttestation<C>]
 	) -> Result<Gwei, Error> {
 		Ok(self.total_balance(&self.unslashed_attesting_indices(attestations)?))
 	}
 
+	/// Get the winning crosslink and attesting indices.
 	pub fn winning_crosslink_and_attesting_indices(
 		&self, epoch: Epoch, shard: Shard
 	) -> Result<(Crosslink, Vec<ValidatorIndex>), Error> {

--- a/beacon/src/lib.rs
+++ b/beacon/src/lib.rs
@@ -1,12 +1,19 @@
+//! Ethereum 2.0 (Serenity) beacon chain state transition implementation.
+
+#![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+/// Primitive types for integer and bytes.
 pub mod primitives;
+/// Types for operations and blocks.
 pub mod types;
+/// Constants used in beacon chain.
 pub mod consts;
+/// Exported beacon chain utilities.
+pub mod utils;
 
 mod error;
 mod config;
-pub mod utils;
 mod executive;
 mod genesis;
 

--- a/beacon/src/primitives/mod.rs
+++ b/beacon/src/primitives/mod.rs
@@ -3,16 +3,19 @@ mod macros;
 
 mod validator_id {
 	impl_beacon_fixed_hash!(H384, 48, typenum::U48);
+	/// Validator id.
 	pub type ValidatorId = H384;
 }
 
 mod signature {
 	impl_beacon_fixed_hash!(H768, 96, typenum::U96);
+	/// Signature.
 	pub type Signature = H768;
 }
 
 mod version {
 	impl_beacon_fixed_hash!(H32, 4, typenum::U4);
+	/// Version.
 	pub type Version = H32;
 }
 
@@ -20,11 +23,17 @@ pub use self::validator_id::{ValidatorId, H384};
 pub use self::signature::{Signature, H768};
 pub use self::version::{Version, H32};
 
+/// Integer type for beacon chain.
 pub type Uint = u64;
 pub use primitive_types::H256;
 
+/// Epoch.
 pub type Epoch = Uint;
+/// Slot.
 pub type Slot = Uint;
+/// Validator index.
 pub type ValidatorIndex = Uint;
+/// Shard.
 pub type Shard = Uint;
+/// Gwei.
 pub type Gwei = Uint;

--- a/beacon/src/types/block.rs
+++ b/beacon/src/types/block.rs
@@ -53,6 +53,7 @@ pub struct BeaconBlockBody<C: Config> {
 
 /// Sealed or unsealed block.
 pub trait Block {
+	/// Configuration of the block.
 	type Config: Config;
 
 	/// Slot of the block.

--- a/beacon/src/types/operation.rs
+++ b/beacon/src/types/operation.rs
@@ -87,6 +87,7 @@ impl<C: Config> From<Attestation<C>> for SigningAttestation<C> {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(deny_unknown_fields))]
 #[cfg_attr(feature = "parity-codec", derive(parity_codec::Encode, parity_codec::Decode))]
 #[cfg_attr(feature = "std", derive(Debug))]
+/// Unsealed attestation.
 pub struct SigningAttestation<C: Config> {
 	/// Attester aggregation bitfield
 	#[bm(compact)]
@@ -141,6 +142,7 @@ impl From<VoluntaryExit> for SigningVoluntaryExit {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(deny_unknown_fields))]
 #[cfg_attr(feature = "parity-codec", derive(parity_codec::Encode, parity_codec::Decode))]
 #[cfg_attr(feature = "std", derive(Debug))]
+/// Unsealed voluntary exit transaction.
 pub struct SigningVoluntaryExit {
 	/// Minimum epoch for processing exit
 	pub epoch: Uint,
@@ -187,6 +189,7 @@ impl From<Transfer> for SigningTransfer {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(deny_unknown_fields))]
 #[cfg_attr(feature = "parity-codec", derive(parity_codec::Encode, parity_codec::Decode))]
 #[cfg_attr(feature = "std", derive(Debug))]
+/// Unsealed transfer transaction.
 pub struct SigningTransfer {
 	/// Sender index
 	pub sender: Uint,

--- a/beacon/src/utils/mod.rs
+++ b/beacon/src/utils/mod.rs
@@ -9,6 +9,7 @@ use crate::primitives::*;
 use core::cmp::max;
 use primitive_types::H256;
 
+/// Convert integer to bytes.
 pub fn to_bytes(v: Uint) -> H256 {
 	let bytes = v.to_le_bytes();
 	let mut ret = H256::default();
@@ -16,12 +17,14 @@ pub fn to_bytes(v: Uint) -> H256 {
 	ret
 }
 
+/// Convert byte to integer.
 pub fn to_uint(v: &[u8]) -> Uint {
 	let mut ret = 0u64.to_le_bytes();
 	(&mut ret[..]).copy_from_slice(&v[..v.len()]);
 	u64::from_le_bytes(ret)
 }
 
+/// Get integer squareroot.
 pub fn integer_squareroot(n: Uint) -> Uint {
 	let mut x = n;
 	let mut y = (x + 1) / 2;
@@ -32,6 +35,7 @@ pub fn integer_squareroot(n: Uint) -> Uint {
 	x
 }
 
+/// Compare hash.
 pub fn compare_hash(a: &H256, b: &H256) -> core::cmp::Ordering {
 	for i in 0..32 {
 		if a[i] > b[i] {
@@ -43,6 +47,7 @@ pub fn compare_hash(a: &H256, b: &H256) -> core::cmp::Ordering {
 	core::cmp::Ordering::Equal
 }
 
+/// Compute shuffled index.
 pub fn shuffled_index<C: Config>(
 	mut index: Uint,
 	index_count: Uint,
@@ -78,6 +83,7 @@ pub fn shuffled_index<C: Config>(
 	Ok(index)
 }
 
+/// Compute committee indices.
 pub fn compute_committee<C: Config>(
 	indices: &[ValidatorIndex],
 	seed: H256,
@@ -94,18 +100,22 @@ pub fn compute_committee<C: Config>(
 	}).collect::<Result<Vec<_>, Error>>()
 }
 
+/// Get epoch of slot.
 pub fn epoch_of_slot<C: Config>(slot: Uint) -> Uint {
 	slot / C::slots_per_epoch()
 }
 
+/// Get start slot of epoch.
 pub fn start_slot_of_epoch<C: Config>(epoch: Uint) -> Uint {
 	epoch * C::slots_per_epoch()
 }
 
+/// Get activation exit epoch.
 pub fn activation_exit_epoch<C: Config>(epoch: Uint) -> Uint {
 	epoch + 1 + C::activation_exit_delay()
 }
 
+/// Check whether given proof is valid merkle branch.
 pub fn is_valid_merkle_branch<C: Config>(
 	leaf: H256, proof: &[H256], depth: u64, index: u64, root: H256
 ) -> bool {
@@ -125,6 +135,7 @@ pub fn is_valid_merkle_branch<C: Config>(
 	value == root
 }
 
+/// BLS signing domain given a domain type and fork version.
 pub fn bls_domain(domain_type: u64, fork_version: Version) -> u64 {
 	let mut bytes = [0u8; 8];
 	(&mut bytes[0..4]).copy_from_slice(&domain_type.to_le_bytes()[0..4]);

--- a/beacon/src/utils/serde.rs
+++ b/beacon/src/utils/serde.rs
@@ -2,7 +2,7 @@ use serde::{Serializer, Deserializer, de::Error as _};
 use impl_serde::serialize;
 use core::convert::TryFrom;
 
-pub fn serialize_bitseq<T: AsRef<[bool]>, S: Serializer>(
+fn serialize_bitseq<T: AsRef<[bool]>, S: Serializer>(
 	value: &T,
 	serializer: S,
 	is_list: bool,
@@ -20,17 +20,19 @@ pub fn serialize_bitseq<T: AsRef<[bool]>, S: Serializer>(
 	serialize::serialize(&bytes, serializer)
 }
 
+/// Serialize a serde bitlist.
 pub fn serialize_bitlist<ML, S: Serializer>(
 	value: &bm_le::MaxVec<bool, ML>,
 	serializer: S
 ) -> Result<S::Ok, S::Error> { serialize_bitseq(value, serializer, true) }
 
+/// Serialize a serde bitvector.
 pub fn serialize_bitvector<L: typenum::Unsigned, S: Serializer>(
 	value: &vecarray::VecArray<bool, L>,
 	serializer: S
 ) -> Result<S::Ok, S::Error> { serialize_bitseq(value, serializer, false) }
 
-pub fn deserialize_bitseq<'a, 'de, D: Deserializer<'de>>(
+fn deserialize_bitseq<'a, 'de, D: Deserializer<'de>>(
 	deserializer: D,
 	is_list: bool,
 ) -> Result<Vec<bool>, D::Error> {
@@ -45,12 +47,14 @@ pub fn deserialize_bitseq<'a, 'de, D: Deserializer<'de>>(
 	Ok(ret)
 }
 
+/// Deserialize a serde bitlist.
 pub fn deserialize_bitlist<'a, 'de, ML, D: Deserializer<'de>>(
 	deserializer: D
 ) -> Result<bm_le::MaxVec<bool, ML>, D::Error> {
 	Ok(bm_le::MaxVec::from(deserialize_bitseq(deserializer, true)?))
 }
 
+/// Deserialize a serde bitvector.
 pub fn deserialize_bitvector<'a, 'de, L: typenum::Unsigned, D: Deserializer<'de>>(
 	deserializer: D
 ) -> Result<vecarray::VecArray<bool, L>, D::Error> {

--- a/utils/ssz/Cargo.toml
+++ b/utils/ssz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssz"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Parity Team <admin@parity.io>", "Wei Tang <hi@that.world>", "Paul Hauner <paul@paulhauner.com>"]
 license-file = "Apache-2.0"
 description = "Simple serialization implementation"
@@ -13,7 +13,7 @@ generic-array = "0.12"
 vecarray = "0.1"
 typenum = "1.10"
 digest = "0.8"
-ssz-derive = { version = "0.1", path = "derive", optional = true }
+ssz-derive = { version = "0.2", path = "derive", optional = true }
 
 [dev-dependencies]
 sha2 = "0.8"

--- a/utils/ssz/Cargo.toml
+++ b/utils/ssz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ssz"
 version = "0.2.0"
 authors = ["Parity Team <admin@parity.io>", "Wei Tang <hi@that.world>", "Paul Hauner <paul@paulhauner.com>"]
-license-file = "Apache-2.0"
+license = "Apache-2.0"
 description = "Simple serialization implementation"
 edition = "2018"
 

--- a/utils/ssz/derive/Cargo.toml
+++ b/utils/ssz/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssz-derive"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 description = "Derive function for simple serialization"
@@ -16,6 +16,6 @@ quote = "0.6"
 deriving = "0.1"
 
 [dev-dependencies]
-ssz = { version = "0.1", path = ".." }
+ssz = { version = "0.2", path = ".." }
 generic-array = "0.12"
 typenum = "1.10"

--- a/utils/ssz/src/lib.rs
+++ b/utils/ssz/src/lib.rs
@@ -16,6 +16,7 @@
 
 //! SimpleSerialization crate written in Rust.
 
+#![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
@@ -48,7 +49,10 @@ pub enum Error {
 	ListTooLarge,
 }
 
+/// Base trait for ssz encoding and decoding.
 pub trait Codec {
+	/// Size of the current type, also indicates whether it is fixed-sized or
+	/// variable-sized.
 	type Size: Size;
 }
 
@@ -76,4 +80,5 @@ pub trait Decode: Codec + Sized {
 	fn decode(value: &[u8]) -> Result<Self, Error>;
 }
 
+/// Type for length offset used for variable-sized item placeholder.
 pub type LengthOffset = u32;

--- a/utils/ssz/src/series.rs
+++ b/utils/ssz/src/series.rs
@@ -3,15 +3,21 @@ use alloc::vec::Vec;
 use alloc::collections::VecDeque;
 
 #[derive(Eq, PartialEq, Clone, Debug)]
+/// Item in a ssz series.
 pub enum SeriesItem {
+	/// Fixed-sized item.
 	Fixed(Vec<u8>),
+	/// Variable-sized item.
 	Variable(Vec<u8>),
 }
 
 #[derive(Default, Eq, PartialEq, Clone, Debug)]
+/// Represents a ssz series. Items in it can either be fixed-sized or
+/// variable-sized.
 pub struct Series(pub Vec<SeriesItem>);
 
 impl Series {
+	/// Encode the current series into raw bytes.
 	pub fn encode(&self) -> Vec<u8> {
 		let mut ret = Vec::new();
 
@@ -49,6 +55,8 @@ impl Series {
 		ret
 	}
 
+	/// Decode raw bytes as a ssz vector, with given types. The length of types
+	/// must equal to the length of values in the vector.
 	pub fn decode_vector(value: &[u8], typs: &[Option<usize>]) -> Result<Self, Error> {
 		let mut ret = Vec::new();
 		let mut variable_offsets = VecDeque::new();
@@ -89,6 +97,7 @@ impl Series {
 		Ok(Self(ret))
 	}
 
+	/// Decode raw bytes as a ssz list, with the given type.
 	pub fn decode_list(value: &[u8], typ: Option<usize>) -> Result<Self, Error> {
 		let mut ret = Vec::new();
 

--- a/utils/ssz/src/size.rs
+++ b/utils/ssz/src/size.rs
@@ -27,6 +27,7 @@ impl Size for VariableSize {
 // unless we have const generics, this is probably the most efficient we can
 // get.
 
+/// Add `A` and `B`, where `A` and `B` are both `Size`.
 pub struct Add<A: Size, B: Size>(PhantomData<(A, B)>);
 
 impl<A: Size, B: Size> Size for Add<A, B> {
@@ -38,6 +39,7 @@ impl<A: Size, B: Size> Size for Add<A, B> {
 	}
 }
 
+/// Multiply `A` and `B`, where `A` and `B` are both `Size`.
 pub struct Mul<A: Size, B: Size>(PhantomData<(A, B)>);
 
 impl<A: Size, B: Size> Size for Mul<A, B> {
@@ -49,6 +51,7 @@ impl<A: Size, B: Size> Size for Mul<A, B> {
 	}
 }
 
+/// Divide `A` by `B`, where `A` and `B` are both `Size`.
 pub struct Div<A: Size, B: Size>(PhantomData<(A, B)>);
 
 impl<A: Size, B: Size> Size for Div<A, B> {
@@ -61,6 +64,7 @@ impl<A: Size, B: Size> Size for Div<A, B> {
 }
 
 #[macro_export]
+/// Shortcut for adding more than two sizes together.
 macro_rules! sum {
 	( $one:ty ) => ( $one );
 	( $first:ty, $( $rest:ty ),* ) => (


### PR DESCRIPTION
* Ensure all items in `ssz` and `beacon` crate have at least simple docs.
* Bump version of `ssz` to `0.2.0` and publish crate.
* Bump version of `beacon` to `0.2.0` and publish crate.