### PR TITLE
srml-casper: implement slashing conditions

### DIFF
--- a/substrate/casper/template/runtime/src/lib.rs
+++ b/substrate/casper/template/runtime/src/lib.rs
@@ -181,6 +181,7 @@ impl casper::Trait for Runtime {
 	type Event = Event;
 	type Call = Call;
 	type UncheckedExtrinsic = UncheckedExtrinsic;
+	type OnSlashing = ();
 }
 
 parameter_types! {


### PR DESCRIPTION
This implements FFG slashing conditions for srml-casper.

* Attestation is changed to use validator id instead of validator index. The former is more stable across session.