### PR TITLE
srml-casper: introduce epoch number

### DIFF
--- a/substrate/casper/primitives/src/lib.rs
+++ b/substrate/casper/primitives/src/lib.rs
@@ -42,6 +42,9 @@ pub type ValidatorWeight = u64;
 /// The index of a validator.
 pub type ValidatorIndex = u64;
 
+/// Type of epoch.
+pub type Epoch = u64;
+
 decl_runtime_apis! {
 	/// API necessary for block authorship with aura.
 	pub trait CasperApi {

--- a/substrate/casper/srml/src/lib.rs
+++ b/substrate/casper/srml/src/lib.rs
@@ -22,7 +22,7 @@ use srml_support::{StorageValue, dispatch::Result, decl_module, decl_storage, de
 use system::ensure_none;
 use sr_primitives::{traits::{One, MaybeDebug, Extrinsic as ExtrinsicT, ValidateUnsigned}, weights::SimpleDispatchInfo};
 use sr_primitives::transaction_validity::{TransactionValidity, TransactionLongevity, ValidTransaction};
-use casper_primitives::{ValidatorId, ValidatorSignature, ValidatorWeight};
+use casper_primitives::{ValidatorId, ValidatorSignature, ValidatorWeight, Epoch};
 use codec::{Encode, Decode};
 use app_crypto::RuntimeAppPublic;
 use rstd::prelude::*;
@@ -38,7 +38,7 @@ impl OnSlashing for () {
 #[derive(Encode, Decode, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Debug))]
 pub struct Checkpoint<T: Trait> {
-	pub number: T::BlockNumber,
+	pub epoch: Epoch,
 	pub hash: T::Hash,
 }
 
@@ -66,12 +66,18 @@ pub trait Trait: session::Trait + MaybeDebug {
 decl_storage! {
 	trait Store for Module<T: Trait> as Casper {
 		Validators get(validators) config(): Vec<(ValidatorId, ValidatorWeight)>;
+
+		CurrentEpoch get(current_epoch) build(|_| 0): Epoch;
 		CurrentEpochNumber get(current_epoch_number) build(|_| 0.into()): T::BlockNumber;
+		PreviousEpoch get(previous_epoch) build(|_| 0): Epoch;
 		PreviousEpochNumber get(previous_epoch_number) build(|_| 0.into()): T::BlockNumber;
+		PreviousJustifiedEpoch get(previous_justified_epoch) build(|_| 0): Epoch;
 		PreviousJustifiedEpochNumber get(previous_justified_epoch_number)
 			build(|_| 0.into()): T::BlockNumber;
+		CurrentJustifiedEpoch get(current_justified_epoch) build(|_| 0): Epoch;
 		CurrentJustifiedEpochNumber get(current_justified_epoch_number)
 			build(|_| 0.into()): T::BlockNumber;
+		FinalizedEpoch get(finalized_epoch) build(|_| 0): Epoch;
 		FinalizedEpochNumber get(finalized_epoch_number)
 			build(|_| 0.into()): T::BlockNumber;
 
@@ -134,9 +140,9 @@ decl_module! {
 				return Err("not slashable because attestation not signed by the same validator")
 			}
 
-			let slashable_cond = attestation_1.target.number == attestation_2.target.number ||
-				(attestation_1.source.number < attestation_2.source.number &&
-				 attestation_2.target.number < attestation_1.target.number);
+			let slashable_cond = attestation_1.target.epoch == attestation_2.target.epoch ||
+				(attestation_1.source.epoch < attestation_2.source.epoch &&
+				 attestation_2.target.epoch < attestation_1.target.epoch);
 
 			if !slashable_cond {
 				return Err("not slashable because it does not satisfy FFG's slashing conditions")
@@ -160,20 +166,24 @@ decl_module! {
 				return Err("invalid attestation signature")
 			}
 
+			let previous_epoch = <PreviousEpoch>::get();
 			let previous_epoch_number = <PreviousEpochNumber<T>>::get();
 			let previous_epoch_hash = <system::Module<T>>::block_hash(previous_epoch_number);
+			let current_epoch = <CurrentEpoch>::get();
 			let current_epoch_number = <CurrentEpochNumber<T>>::get();
 			let current_epoch_hash = <system::Module<T>>::block_hash(current_epoch_number);
+			let previous_justified_epoch = <PreviousJustifiedEpoch>::get();
 			let previous_justified_epoch_number = <PreviousJustifiedEpochNumber<T>>::get();
 			let previous_justified_epoch_hash =
 				<system::Module<T>>::block_hash(previous_justified_epoch_number);
+			let current_justified_epoch = <CurrentJustifiedEpoch>::get();
 			let current_justified_epoch_number = <CurrentJustifiedEpochNumber<T>>::get();
 			let current_justified_epoch_hash =
 				<system::Module<T>>::block_hash(current_justified_epoch_number);
 
-			if attestation.source.number == previous_justified_epoch_number &&
+			if attestation.source.epoch == previous_justified_epoch &&
 				attestation.source.hash == previous_justified_epoch_hash &&
-				attestation.target.number == previous_epoch_number &&
+				attestation.target.epoch == previous_epoch &&
 				attestation.target.hash == previous_epoch_hash
 			{
 				let mut previous_epoch_attestations = <PreviousEpochAttestations<T>>::get();
@@ -181,9 +191,9 @@ decl_module! {
 				<PreviousEpochAttestationsCount>::put(previous_epoch_attestations.len() as u32);
 				<PreviousEpochAttestations<T>>::put(previous_epoch_attestations);
 				Self::deposit_event(RawEvent::OnNewPreviousEpochAttestation(attestation));
-			} else if attestation.source.number == current_justified_epoch_number &&
+			} else if attestation.source.epoch == current_justified_epoch &&
 				attestation.source.hash == current_justified_epoch_hash &&
-				attestation.target.number == current_epoch_number &&
+				attestation.target.epoch == current_epoch &&
 				attestation.target.hash == current_epoch_hash
 			{
 				let mut current_epoch_attestations = <CurrentEpochAttestations<T>>::get();
@@ -228,15 +238,17 @@ impl<T: Trait> Module<T> {
 						.map(|location| (index as u32, &local_keys[location]))
 				})
 			{
+				let source_epoch = <CurrentJustifiedEpoch>::get();
 				let source_number = <CurrentJustifiedEpochNumber<T>>::get();
+				let target_epoch = <CurrentEpoch>::get();
 				let target_number = <CurrentEpochNumber<T>>::get();
 
 				let source = Checkpoint::<T> {
-					number: source_number,
+					epoch: source_epoch,
 					hash: <system::Module<T>>::block_hash(source_number),
 				};
 				let target = Checkpoint::<T> {
-					number: target_number,
+					epoch: target_epoch,
 					hash: <system::Module<T>>::block_hash(target_number),
 				};
 				let attestation = Attestation::<T> {
@@ -302,24 +314,49 @@ impl<T: Trait> session::OneSessionHandler<T::AccountId> for Module<T> {
 		justification_bits[1..].copy_from_slice(
 			&old_justification_bits[0..3]
 		);
+		let old_previous_justified_epoch = <PreviousJustifiedEpoch>::get();
 		let old_previous_justified_epoch_number = <PreviousJustifiedEpochNumber<T>>::get();
+		let old_current_justified_epoch = <CurrentJustifiedEpoch>::get();
 		let old_current_justified_epoch_number = <CurrentJustifiedEpochNumber<T>>::get();
+		<PreviousJustifiedEpoch>::put(<CurrentJustifiedEpoch>::get());
 		<PreviousJustifiedEpochNumber<T>>::put(<CurrentJustifiedEpochNumber<T>>::get());
 
 		if previous_matching_target_balance * 3 >= total_balance * 2 {
+			<CurrentJustifiedEpoch>::put(<PreviousEpoch>::get());
 			<CurrentJustifiedEpochNumber<T>>::put(<PreviousEpochNumber<T>>::get());
 			justification_bits[1] = true;
 		}
 		if current_matching_target_balance * 3 >= total_balance * 2 {
+			<CurrentJustifiedEpoch>::put(<CurrentEpoch>::get());
 			<CurrentJustifiedEpochNumber<T>>::put(<CurrentEpochNumber<T>>::get());
 			justification_bits[0] = true;
 		}
 
-		if justification_bits[1..3].iter().all(|v| *v) {
+		if justification_bits[1..4].iter().all(|v| *v) &&
+			old_previous_justified_epoch + 3 == <CurrentEpoch>::get()
+		{
+			<FinalizedEpoch>::put(old_previous_justified_epoch);
 			<FinalizedEpochNumber<T>>::put(old_previous_justified_epoch_number);
 		}
 
-		if justification_bits[0..2].iter().all(|v| *v) {
+		if justification_bits[1..3].iter().all(|v| *v) &&
+			old_previous_justified_epoch + 2 == <CurrentEpoch>::get()
+		{
+			<FinalizedEpoch>::put(old_previous_justified_epoch);
+			<FinalizedEpochNumber<T>>::put(old_previous_justified_epoch_number);
+		}
+
+		if justification_bits[0..3].iter().all(|v| *v) &&
+			old_current_justified_epoch + 2 == <CurrentEpoch>::get()
+		{
+			<FinalizedEpoch>::put(old_current_justified_epoch);
+			<FinalizedEpochNumber<T>>::put(old_current_justified_epoch_number);
+		}
+
+		if justification_bits[0..2].iter().all(|v| *v) &&
+			old_current_justified_epoch + 1 == <CurrentEpoch>::get()
+		{
+			<FinalizedEpoch>::put(old_current_justified_epoch);
 			<FinalizedEpochNumber<T>>::put(old_current_justified_epoch_number);
 		}
 
@@ -330,7 +367,9 @@ impl<T: Trait> session::OneSessionHandler<T::AccountId> for Module<T> {
 		if changed {
 			<Validators>::put(new_validators.map(|(_, k)| (k, 1u64)).collect::<Vec<_>>());
 		}
+		<PreviousEpoch>::put(<CurrentEpoch>::get());
 		<PreviousEpochNumber<T>>::put(<CurrentEpochNumber<T>>::get());
+		<CurrentEpoch>::put(<CurrentEpoch>::get() + 1);
 		<CurrentEpochNumber<T>>::put(<system::Module<T>>::block_number());
 	}
 


### PR DESCRIPTION
Previously, we use block number to store where an epoch starts, and the current justified and finalized number. However, in Substrate, session can have variable length. In this PR we introduce epoch number so that it's always clearly know how many epochs the justified/finalized block is behind the current.