### PR TITLE
wasm: fix U1099511627776 exceeding u32 limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,7 +189,7 @@ dependencies = [
 name = "beacon"
 version = "0.2.0"
 dependencies = [
- "bm-le 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bm-le 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fixed-hash 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "bm"
-version = "0.10.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -364,11 +364,11 @@ dependencies = [
 
 [[package]]
 name = "bm-le"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bm 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "bm-le-derive 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bm 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bm-le-derive 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 4.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "bm-le-derive"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "deriving 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3650,7 +3650,7 @@ dependencies = [
  "blockchain-network-simple 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "blockchain-rocksdb 0.1.0",
  "bls-aggregates 0.7.0 (git+https://github.com/sigp/signature-schemes)",
- "bm-le 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bm-le 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmd-ghost 0.1.0",
  "parity-codec 4.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4097,7 +4097,7 @@ dependencies = [
 name = "ssz"
 version = "0.2.0"
 dependencies = [
- "bm-le 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bm-le 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4125,7 +4125,7 @@ name = "ssztests"
 version = "0.1.0"
 dependencies = [
  "beacon 0.2.0",
- "bm-le 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bm-le 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5868,9 +5868,9 @@ dependencies = [
 "checksum blockchain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "beacfb01421b763e29d6fc003cb07f3d7a7a853ee2d1e7d74cbe6c0ac9c896f6"
 "checksum blockchain-network-simple 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fd64fb84d011c4aeb01aef31d1b61fd932beb6c80459993b54fce1aed7895f89"
 "checksum bls-aggregates 0.7.0 (git+https://github.com/sigp/signature-schemes)" = "<none>"
-"checksum bm 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e353d9dc247a26a710b40a12e194b93b481cf18c3bd966518b80f4161d852caa"
-"checksum bm-le 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2e155152543e2c752d35ef21930f741320d20fd6caa539535a1e589103d4b794"
-"checksum bm-le-derive 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de454908871d44e558cc267dc969085289e8b6cb65f631848baec7fa2c0027e7"
+"checksum bm 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a72904cc3fa4c32719b84c4d8ae2d6458d6254d55f4ff6fc53f05ceb78ccc20f"
+"checksum bm-le 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "59b1300cf24049f7e8bbdae91084516c24f3f072c5e5db8eb1d8deacd862c278"
+"checksum bm-le-derive 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f25f41167e5a88f6c3c959f5909ae122b3eb21890451302c11905685f06ca87"
 "checksum bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0de79cfb98e7aa9988188784d8664b4b5dad6eaaa0863b91d9a4ed871d4f7a42"
 "checksum bstr 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e0a692f1c740e7e821ca71a22cf99b9b2322dfa94d10f71443befb1797b3946a"
 "checksum bumpalo 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2cd43d82f27d68911e6ee11ee791fb248f138f5d69424dc02e098d4f152b0b05"

--- a/beacon/Cargo.toml
+++ b/beacon/Cargo.toml
@@ -12,7 +12,7 @@ impl-serde = { version = "0.1", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 parity-codec = { version = "4.0", optional = true, features = ["derive"] }
 ssz = { version = "0.2", path = "../utils/ssz", default-features = false, features = ["derive"] }
-bm-le = { version = "0.10", default-features = false, features = ["derive"] }
+bm-le = { version = "0.11", default-features = false, features = ["derive"] }
 fixed-hash = { version = "0.3.0", default-features = false }
 sha2 = { version = "0.8", default-features = false }
 digest = "0.8"

--- a/beacon/wasm/Cargo.lock
+++ b/beacon/wasm/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
 name = "beacon"
 version = "0.2.0"
 dependencies = [
- "bm-le 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bm-le 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fixed-hash 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "bm"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -69,11 +69,11 @@ dependencies = [
 
 [[package]]
 name = "bm-le"
-version = "0.8.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bm 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bm-le-derive 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bm 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bm-le-derive 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 4.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "bm-le-derive"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "deriving 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -151,13 +151,14 @@ dependencies = [
 
 [[package]]
 name = "eth2"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "beacon 0.2.0",
- "bm-le 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bm-le 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -403,7 +404,7 @@ dependencies = [
 name = "ssz"
 version = "0.2.0"
 dependencies = [
- "bm-le 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bm-le 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -548,9 +549,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitvec 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b67491e1cc6f37da6c4415cd743cb8d2e2c65388acc91ca3094a054cbf3cbd0c"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
-"checksum bm 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "471173d9db9122f3c614d99fd2981558552412766d3a6ed6432e9ea7c72cba66"
-"checksum bm-le 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ee9704ea6f82754f7942e8f381314a9eb77d2bcc549ebe5a9ff6357462c20f64"
-"checksum bm-le-derive 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f2cc8f489cf0988df4e583011c699a383379d96095f7486eb81a9c6e52a41b19"
+"checksum bm 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a72904cc3fa4c32719b84c4d8ae2d6458d6254d55f4ff6fc53f05ceb78ccc20f"
+"checksum bm-le 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "59b1300cf24049f7e8bbdae91084516c24f3f072c5e5db8eb1d8deacd862c278"
+"checksum bm-le-derive 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f25f41167e5a88f6c3c959f5909ae122b3eb21890451302c11905685f06ca87"
 "checksum bumpalo 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2cd43d82f27d68911e6ee11ee791fb248f138f5d69424dc02e098d4f152b0b05"
 "checksum byte-slice-cast 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7cbcbf18128ec71d8d4a0d054461ec59fff5b75b7d10a4c9b7c7cb1a379c3e77"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"

--- a/beacon/wasm/Cargo.toml
+++ b/beacon/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eth2"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Minimal Serenity beacon chain implementation compiled to WebAssembly"
 license = "GPL-3.0"
@@ -13,8 +13,9 @@ crate-type = ["cdylib"]
 wasm-bindgen = "0.2.48"
 js-sys = "0.3.25"
 beacon = { path = ".." }
-bm-le = { version = "0.8", default-features = false, features = ["derive"] }
+bm-le = { version = "0.11", default-features = false, features = ["derive"] }
 serde_json = "1.0"
 serde = "1.0"
+typenum = "1.10"
 
 [workspace]

--- a/beacon/wasm/index.js
+++ b/beacon/wasm/index.js
@@ -1,7 +1,7 @@
 // Note that a dynamic `import` statement here is required due to
 // webpack/webpack#6615, but in theory `import { greet } from './pkg/hello_world';`
 // will work here one day as well!
-const rust = import('./pkg/beacon_wasm');
+const rust = import('./pkg/eth2');
 
 const state = {
 	"genesis_time": 0,

--- a/blockchain/Cargo.toml
+++ b/blockchain/Cargo.toml
@@ -19,4 +19,4 @@ sha2 = "0.8"
 bls-aggregates = { git = "https://github.com/sigp/signature-schemes" }
 rand = "0.6"
 rocksdb = "0.12"
-bm-le = { version = "0.10", features = ["derive"] }
+bm-le = { version = "0.11", features = ["derive"] }

--- a/utils/ssz/Cargo.toml
+++ b/utils/ssz/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 primitive-types = { version = "0.4", default-features = false }
-bm-le = "0.10"
+bm-le = "0.11"
 generic-array = "0.12"
 vecarray = "0.1"
 typenum = "1.10"

--- a/yamltests/ssztests/Cargo.toml
+++ b/yamltests/ssztests/Cargo.toml
@@ -9,7 +9,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 clap = "2.32"
 ssz = { path = "../../utils/ssz" }
-bm-le = "0.10"
+bm-le = "0.11"
 beacon = { path = "../../beacon" }
 crypto = { package = "shasper-crypto", path = "../../crypto" }
 hex = "0.3"


### PR DESCRIPTION
This was the cause of `U1099511627776::to_usize() == 0`. The fix is explicitly use `u64` in `bm` crate.