### PR TITLE
beacon-wasm: use the builtin serde feature provided by wasm-bindgen

### DIFF
--- a/beacon/wasm/Cargo.lock
+++ b/beacon/wasm/Cargo.lock
@@ -151,14 +151,10 @@ dependencies = [
 
 [[package]]
 name = "eth2"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "beacon 0.2.0",
- "bm-le 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -231,14 +227,6 @@ dependencies = [
 name = "itoa"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "js-sys"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "wasm-bindgen 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "lazy_static"
@@ -481,6 +469,8 @@ name = "wasm-bindgen"
 version = "0.2.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-macro 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -570,7 +560,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum impl-serde 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5158079de9d4158e0ce1de3ae0bd7be03904efc40b3d7dd8b8c301cbf6b52b56"
 "checksum impl-serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d26be4b97d738552ea423f76c4f681012ff06c3fa36fa968656b3679f60b4a1"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
-"checksum js-sys 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)" = "da3ea71161651a4cd97d999b2da139109c537b15ab33abc8ae4ead38deac8a03"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.61 (registry+https://github.com/rust-lang/crates.io-index)" = "c665266eb592905e8503ba3403020f4b8794d26263f412ca33171600eca9a6fa"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"

--- a/beacon/wasm/Cargo.toml
+++ b/beacon/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eth2"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Minimal Serenity beacon chain implementation compiled to WebAssembly"
 license = "GPL-3.0"
@@ -10,12 +10,8 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.48"
-js-sys = "0.3.25"
+wasm-bindgen = { version = "0.2.48", features = ["serde-serialize"] }
 beacon = { path = ".." }
-bm-le = { version = "0.11", default-features = false, features = ["derive"] }
-serde_json = "1.0"
 serde = "1.0"
-typenum = "1.10"
 
 [workspace]

--- a/beacon/wasm/src/lib.rs
+++ b/beacon/wasm/src/lib.rs
@@ -1,7 +1,6 @@
 use wasm_bindgen::prelude::*;
 use beacon::{BLSNoVerification, BLSConfig, Config, MinimalConfig, MainnetConfig, BeaconState};
 use beacon::types::BeaconBlock;
-use js_sys::JSON;
 
 #[wasm_bindgen]
 pub fn execute_minimal(block: &JsValue, state: &JsValue) -> Result<JsValue, JsValue> {
@@ -16,16 +15,12 @@ pub fn execute_mainnet(block: &JsValue, state: &JsValue) -> Result<JsValue, JsVa
 fn execute<C: Config, BLS: BLSConfig>(block: &JsValue, state: &JsValue) -> Result<JsValue, JsValue> where
 	C: serde::Serialize + serde::de::DeserializeOwned,
 {
-	let block_string: String = JSON::stringify(block)?.into();
-	let block: BeaconBlock<C> = serde_json::from_str(&block_string)
-		.map_err(|e| JsValue::from(format!("{:?}", e)))?;
-	let state_string: String = JSON::stringify(state)?.into();
-	let mut state: BeaconState<C> = serde_json::from_str(&state_string)
-		.map_err(|e| JsValue::from(format!("{:?}", e)))?;
+	let block: BeaconBlock<C> = block.into_serde().map_err(|e| JsValue::from(format!("{:?}", e)))?;
+	let mut state: BeaconState<C> = state.into_serde().map_err(|e| JsValue::from(format!("{:?}", e)))?;
 
 	beacon::execute_block::<C, BLS>(
 		&block, &mut state
 	).map_err(|e| JsValue::from(format!("{:?}", e)))?;
 
-	Ok(JSON::parse(&serde_json::to_string(&state).map_err(|e| JsValue::from(format!("{:?}", e)))?)?)
+	Ok(JsValue::from_serde(&state).map_err(|e| JsValue::from(format!("{:?}", e)))?)
 }


### PR DESCRIPTION
This replaces `serde-json` encoding/decoding with builtin serde feature provided by `wasm-bindgen`. Should be faster compared with before.