### PR TITLE
beacon-wasm: update cargo lock

### DIFF
--- a/beacon/wasm/Cargo.lock
+++ b/beacon/wasm/Cargo.lock
@@ -12,7 +12,9 @@ dependencies = [
 name = "beacon"
 version = "0.2.0"
 dependencies = [
- "bm-le 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "beacon-primitives 0.2.0",
+ "bm 0.11.0",
+ "bm-le 0.11.0",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fixed-hash 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -24,6 +26,21 @@ dependencies = [
  "ssz 0.2.0",
  "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vecarray 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "beacon-primitives"
+version = "0.2.0"
+dependencies = [
+ "bm-le 0.11.0",
+ "fixed-hash 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-serde 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-codec 4.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "primitive-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ssz 0.2.0",
+ "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -58,7 +75,6 @@ dependencies = [
 [[package]]
 name = "bm"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -70,10 +86,9 @@ dependencies = [
 [[package]]
 name = "bm-le"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bm 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bm-le-derive 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bm 0.11.0",
+ "bm-le-derive 0.11.0",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 4.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -86,7 +101,6 @@ dependencies = [
 [[package]]
 name = "bm-le-derive"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "deriving 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -151,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "eth2"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "beacon 0.2.0",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -392,7 +406,7 @@ dependencies = [
 name = "ssz"
 version = "0.2.0"
 dependencies = [
- "bm-le 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bm-le 0.11.0",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -539,9 +553,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitvec 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b67491e1cc6f37da6c4415cd743cb8d2e2c65388acc91ca3094a054cbf3cbd0c"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
-"checksum bm 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a72904cc3fa4c32719b84c4d8ae2d6458d6254d55f4ff6fc53f05ceb78ccc20f"
-"checksum bm-le 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "59b1300cf24049f7e8bbdae91084516c24f3f072c5e5db8eb1d8deacd862c278"
-"checksum bm-le-derive 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f25f41167e5a88f6c3c959f5909ae122b3eb21890451302c11905685f06ca87"
 "checksum bumpalo 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2cd43d82f27d68911e6ee11ee791fb248f138f5d69424dc02e098d4f152b0b05"
 "checksum byte-slice-cast 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7cbcbf18128ec71d8d4a0d054461ec59fff5b75b7d10a4c9b7c7cb1a379c3e77"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"

--- a/beacon/wasm/Cargo.toml
+++ b/beacon/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eth2"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Minimal Serenity beacon chain implementation compiled to WebAssembly"
 license = "GPL-3.0"


### PR DESCRIPTION
Update the `Cargo.lock` file for `beacon-wasm` and release `v0.2.3`.